### PR TITLE
Service can now auto-config a OneFS cluster

### DIFF
--- a/WorkerDockerfile
+++ b/WorkerDockerfile
@@ -1,10 +1,20 @@
-FROM willnx/vlab-base
+FROM ubuntu:18.04
+LABEL maintainer="willnx84@gmail.com"
 
+RUN apt update && apt upgrade --yes
+RUN apt install --yes wget python3 python3-dev openssl gcc \
+             libc-dev libffi-dev libpcre3 libpcre3-dev firefox
+
+RUN wget --no-check-certificate -O /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py && \
+    python3 /tmp/get-pip.py && \
+    rm /tmp/get-pip.py
+
+COPY geckodriver /usr/local/bin
 COPY dist/*.whl /tmp
 
 RUN pip install /tmp/*.whl && rm /tmp/*.whl
-RUN apk del gcc
+RUN apt remove --yes gcc
 
-WORKDIR /usr/lib/python3.6/site-packages/vlab_onefs_api/lib/worker
-USER nobody
+WORKDIR /usr/local/lib/python3.6/dist-packages/vlab_onefs_api/lib/worker
+
 CMD ["celery", "-A", "tasks", "worker"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,12 +18,12 @@ services:
     image:
       willnx/vlab-onefs-worker
     volumes:
-      - ./vlab_onefs_api:/usr/lib/python3.6/site-packages/vlab_onefs_api
+      - ./vlab_onefs_api:/usr/local/lib/python3.6/dist-packages/vlab_onefs_api/
       - /mnt/raid/images/onefs:/images:ro
     environment:
-      - INF_VCENTER_SERVER=changeME
-      - INF_VCENTER_USER=changeME
-      - INF_VCENTER_PASSWORD=changeME
+      - INF_VCENTER_SERVER=virtlab.igs.corp
+      - INF_VCENTER_USER=Administrator@vsphere.local
+      - INF_VCENTER_PASSWORD=1.Password
       - INF_VCENTER_TOP_LVL_DIR=/vlab
 
   onefs-broker:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-onefs-api",
       author="Nicholas Willhite,",
       author_email='willnx84@gmail.com',
-      version='2018.07.25',
+      version='2018.11.14',
       packages=find_packages(),
       include_package_data=True,
       package_files={'vlab_onefs_api' : ['app.ini']},

--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,6 @@ setup(name="vlab-onefs-api",
       package_files={'vlab_onefs_api' : ['app.ini']},
       description="Deploy vOneFS nodes in your vLab",
       install_requires=['flask', 'ldap3', 'pyjwt', 'uwsgi', 'vlab-api-common',
-                        'ujson', 'cryptography', 'vlab-inf-common', 'celery']
+                        'ujson', 'cryptography', 'vlab-inf-common', 'celery',
+                        'selenium']
       )

--- a/tests/test_api_schemas.py
+++ b/tests/test_api_schemas.py
@@ -51,6 +51,16 @@ class TestOneFSViewSchema(unittest.TestCase):
 
         self.assertTrue(schema_valid)
 
+    def test_config_schema(self):
+        """The schema defined for POST on /config is valid"""
+        try:
+            Draft4Validator.check_schema(onefs.OneFSView.CONFIG_SCHEMA)
+            schema_valid = True
+        except RuntimeError:
+            schema_valid = False
+
+        self.assertTrue(schema_valid)
+
     def test_delete(self):
         """The DELETE schema happy path test"""
         body = {'name': "isi01"}
@@ -133,6 +143,70 @@ class TestOneFSViewSchema(unittest.TestCase):
                  'image': "8.0.0.4"}
         try:
             validate(body, onefs.OneFSView.POST_SCHEMA)
+            ok = False
+        except ValidationError:
+            ok = True
+
+        self.assertTrue(ok)
+
+    def test_config_join(self):
+        """The schema for /config supports joining a node to a cluster"""
+        body = {'name': 'woot-2',
+                'cluster_name': 'woot',
+                'join': True}
+        try:
+            validate(body, onefs.OneFSView.CONFIG_SCHEMA)
+            ok = True
+        except ValidationError:
+            ok = False
+
+        self.assertTrue(ok)
+
+    def test_config_new(self):
+        """The schema for /config supports creating a new cluster"""
+        body = {'cluster_name': "woot",
+                'version': "8.0.1.2",
+                'name': 'woot-1',
+                'int_netmask': '255.255.255.0',
+                'int_ip_low': '200.1.1.1',
+                'int_ip_high': '200.1.1.10',
+                'ext_netmask': '255.255.255.0',
+                'ext_ip_low': '10.7.1.2',
+                'ext_ip_high': '10.7.1.10',
+                'gateway': '10.7.1.1',
+                'encoding': "utf-8",
+                'sc_zonename': 'woot.vlab.local',
+                'smartconnect_ip': '10.7.1.11',
+                'dns_servers': ['1.1.1.1', '8.8.8.8']
+               }
+        try:
+            validate(body, onefs.OneFSView.CONFIG_SCHEMA)
+            ok = True
+        except ValidationError:
+            ok = False
+
+        self.assertTrue(ok)
+
+    def test_config_join_mutext(self):
+        """The supplying 'join' when creating a new cluster is invalid on /config """
+        body = {'cluster_name': "woot",
+                'version': "8.0.1.2",
+                'name': 'woot-1',
+                'int_netmask': '255.255.255.0',
+                'int_ip_low': '200.1.1.1',
+                'int_ip_high': '200.1.1.10',
+                'ext_netmask': '255.255.255.0',
+                'ext_ip_low': '10.7.1.2',
+                'ext_ip_high': '10.7.1.10',
+                'gateway': '10.7.1.1',
+                'encoding': "utf-8",
+                'sc_zonename': 'woot.vlab.local',
+                'smartconnect_ip': '10.7.1.11',
+                'dns_servers': ['1.1.1.1', '8.8.8.8'],
+                'join' : True,
+               }
+        try:
+            validate(body, onefs.OneFSView.CONFIG_SCHEMA)
             ok = False
         except ValidationError:
             ok = True

--- a/tests/test_setup_onefs.py
+++ b/tests/test_setup_onefs.py
@@ -1,0 +1,432 @@
+# -*- coding: UTF-8 -*-
+"""
+A suite of tests for the functions in setup_onefs.py
+"""
+import unittest
+from unittest.mock import patch, MagicMock
+
+from vlab_onefs_api.lib.worker import setup_onefs
+
+
+class TestvSphereConsole(unittest.TestCase):
+    """A suite of test cases for vSphereConsole object"""
+
+    @patch.object(setup_onefs, 'webdriver')
+    def test_init(self, fake_webdriver):
+        """``__init__`` works for vSphereConsole"""
+        console = setup_onefs.vSphereConsole(url='https://someHTMLconsole.com')
+
+        self.assertTrue(isinstance(console, setup_onefs.vSphereConsole))
+
+    @patch.object(setup_onefs.vSphereConsole, '_login')
+    @patch.object(setup_onefs, 'webdriver')
+    def test_auto_login(self, fake_webdriver, fake_login):
+        """Creating the vSphereConsole object automatically logs a user into the HTML console"""
+        console = setup_onefs.vSphereConsole(url='https://someHTMLconsole.com')
+
+        self.assertEqual(fake_login.call_count, 1)
+
+    @patch.object(setup_onefs.vSphereConsole, '_get_console')
+    @patch.object(setup_onefs, 'webdriver')
+    def test_finds_console(self, fake_webdriver, fake_get_console):
+        """Creating the vSphereConsole object binds to the console HTML object"""
+        console = setup_onefs.vSphereConsole(url='https://someHTMLconsole.com')
+
+        self.assertEqual(fake_get_console.call_count, 1)
+
+    @patch.object(setup_onefs, 'webdriver')
+    def test_with(self, fake_webdriver):
+        """vSphereConsole auto-closes the session upon exiting ``with`` statement"""
+        fake_driver = MagicMock()
+        fake_webdriver.Firefox.return_value = fake_driver
+        with setup_onefs.vSphereConsole(url='https://someHTMLconsole.com') as console:
+            pass
+
+        self.assertEqual(fake_driver.quit.call_count, 1)
+
+    @patch.object(setup_onefs.vSphereConsole, '_get_console')
+    @patch.object(setup_onefs.time, 'sleep')
+    @patch.object(setup_onefs, 'webdriver')
+    def test_send_keys(self, fake_webdriver, fake_sleep, fake_get_console):
+        """``send_keys`` Sends the supplied intput to the HTML console"""
+        fake_console = MagicMock()
+        fake_get_console.return_value = fake_console
+        with setup_onefs.vSphereConsole(url='https://someHTMLconsole.com') as console:
+            console.send_keys('woot', auto_enter=False)
+
+        the_args, _ = fake_console.send_keys.call_args
+        expected = ('woot',)
+
+        self.assertEqual(the_args, expected)
+
+    @patch.object(setup_onefs.vSphereConsole, '_get_console')
+    @patch.object(setup_onefs.time, 'sleep')
+    @patch.object(setup_onefs, 'webdriver')
+    def test_send_keys_pauses(self, fake_webdriver, fake_sleep, fake_get_console):
+        """``send_keys`` pauses to let the HTML console 'catch up'"""
+        fake_console = MagicMock()
+        fake_get_console.return_value = fake_console
+        with setup_onefs.vSphereConsole(url='https://someHTMLconsole.com') as console:
+            console.send_keys('woot', auto_enter=False)
+
+        self.assertEqual(fake_sleep.call_count, 1)
+
+    @patch.object(setup_onefs.vSphereConsole, '_get_console')
+    @patch.object(setup_onefs.time, 'sleep')
+    @patch.object(setup_onefs, 'webdriver')
+    def test_send_keys_auto_enters(self, fake_webdriver, fake_sleep, fake_get_console):
+        """``send_keys`` automatically sends the ENTER key by default"""
+        fake_console = MagicMock()
+        fake_get_console.return_value = fake_console
+        with setup_onefs.vSphereConsole(url='https://someHTMLconsole.com') as console:
+            console.send_keys('woot')
+
+        the_args, _ = fake_console.send_keys.call_args
+        expected = (setup_onefs.Keys.ENTER,)
+
+        self.assertEqual(the_args, expected)
+
+@patch.object(setup_onefs.time, 'sleep')
+@patch.object(setup_onefs, 'vSphereConsole')
+class TestSetupFunctions(unittest.TestCase):
+    """A suite of test cases for the functions within setup_onefs.py"""
+
+    def test_join_existing_cluster(self, fake_vSphereConsole, fake_sleep):
+        """``join_existing_cluster`` returns None"""
+        fake_logger = MagicMock()
+        output = setup_onefs.join_existing_cluster('https://someHTMLconsole.com', 'mycluster', fake_logger)
+        expected = None
+
+        self.assertEqual(output, expected)
+
+
+    def test_join_existing_cluster_with(self, fake_vSphereConsole, fake_sleep):
+        """``join_existing_cluster`` uses context manager of vSphereConsole"""
+        fake_logger = MagicMock()
+        setup_onefs.join_existing_cluster('https://someHTMLconsole.com', 'mycluster', fake_logger)
+
+        call_count = fake_vSphereConsole.return_value.__enter__.call_count
+        expected = 1
+
+        self.assertEqual(call_count, expected)
+
+    def test_join_existing_cluster_pause(self, fake_vSphereConsole, fake_sleep):
+        """``join_existing_cluster`` waits for the disks to format"""
+        fake_logger = MagicMock()
+        setup_onefs.join_existing_cluster('https://someHTMLconsole.com', 'mycluster', fake_logger)
+
+        paused = fake_sleep.called
+
+        self.assertTrue(paused)
+
+    @patch.object(setup_onefs, 'format_disks')
+    def test_join_existing_cluster_formats(self, fake_vSphereConsole, fake_sleep, fake_format_disks):
+        """``join_existing_cluster`` formats the disks"""
+        fake_logger = MagicMock()
+        setup_onefs.join_existing_cluster('https://someHTMLconsole.com', 'mycluster', fake_logger)
+
+        formatted_disks = fake_format_disks.called
+
+        self.assertTrue(formatted_disks)
+
+    def test_configure_new_cluster(self, fake_vSphereConsole, fake_sleep):
+        """``configure_new_cluster`` returns None"""
+        fake_logger = MagicMock()
+        output = setup_onefs.configure_new_cluster(version='8.1.1.1',
+                                                   logger=fake_logger,
+                                                   console_url='https://someHTMLconsole.com',
+                                                   cluster_name='mycluster',
+                                                   int_netmask='255.255.255.0',
+                                                   int_ip_low='8.6.7.5',
+                                                   int_ip_high='8.6.7.50',
+                                                   ext_netmask='255.255.255.0',
+                                                   ext_ip_low='3.0.9.2',
+                                                   ext_ip_high='3.0.9.20',
+                                                   gateway='3.0.9.1',
+                                                   dns_servers='1.1.1.1',
+                                                   encoding='utf-8',
+                                                   sc_zonename='myzone.foo.org',
+                                                   smartconnect_ip='3.0.9.21')
+        expected = None
+
+        self.assertEqual(output, expected)
+
+    @patch.object(setup_onefs, 'configure_new_8_0_cluster')
+    def test_configure_new_cluster_8_0(self, fake_configure_new_8_0_cluster, fake_vSphereConsole, fake_sleep):
+        """``configure_new_cluster`` executes the correct function for OneFS 8.0.0.x"""
+        fake_logger = MagicMock()
+        setup_onefs.configure_new_cluster(version='8.0.0.1', logger=fake_logger)
+
+        called = fake_configure_new_8_0_cluster.call_count
+        expected = 1
+
+        self.assertEqual(called, expected)
+
+    @patch.object(setup_onefs, 'configure_new_8_1_cluster')
+    def test_configure_new_cluster_8_1_0(self, fake_configure_new_8_1_cluster, fake_vSphereConsole, fake_sleep):
+        """``configure_new_cluster`` executes the correct function for OneFS 8.1.0.x"""
+        fake_logger = MagicMock()
+        setup_onefs.configure_new_cluster(version='8.1.0.3', logger=fake_logger)
+
+        called = fake_configure_new_8_1_cluster.call_count
+        expected = 1
+
+        self.assertEqual(called, expected)
+
+    @patch.object(setup_onefs, 'configure_new_8_1_cluster')
+    def test_configure_new_cluster_8_1_1(self, fake_configure_new_8_1_cluster, fake_vSphereConsole, fake_sleep):
+        """``configure_new_cluster`` executes the correct function for OneFS 8.1.1.x"""
+        fake_logger = MagicMock()
+        setup_onefs.configure_new_cluster(version='8.1.1.2', logger=fake_logger)
+
+        called = fake_configure_new_8_1_cluster.call_count
+        expected = 1
+
+        self.assertEqual(called, expected)
+
+    @patch.object(setup_onefs, 'configure_new_8_1_2_cluster')
+    def test_configure_new_cluster_8_1_2(self, fake_configure_new_8_1_2_cluster, fake_vSphereConsole, fake_sleep):
+        """``configure_new_cluster`` executes the correct function for OneFS 8.1.2.x"""
+        fake_logger = MagicMock()
+        setup_onefs.configure_new_cluster(version='8.1.2.0', logger=fake_logger)
+
+        called = fake_configure_new_8_1_2_cluster.call_count
+        expected = 1
+
+        self.assertEqual(called, expected)
+
+    def test_configure_new_8_0_cluster(self, fake_vSphereConsole, fake_sleep):
+        """``configure_new_8_0_cluster`` returns None"""
+        fake_logger = MagicMock()
+        output = setup_onefs.configure_new_8_0_cluster(logger=fake_logger,
+                                                       console_url='https://someHTMLconsole.com',
+                                                       cluster_name='mycluster',
+                                                       int_netmask='255.255.255.0',
+                                                       int_ip_low='8.6.7.5',
+                                                       int_ip_high='8.6.7.50',
+                                                       ext_netmask='255.255.255.0',
+                                                       ext_ip_low='3.0.9.2',
+                                                       ext_ip_high='3.0.9.20',
+                                                       gateway='3.0.9.1',
+                                                       dns_servers='1.1.1.1',
+                                                       encoding='utf-8',
+                                                       sc_zonename='myzone.foo.org',
+                                                       smartconnect_ip='3.0.9.21')
+        expected = None
+
+        self.assertEqual(output, expected)
+
+    def test_configure_new_8_1_cluster(self, fake_vSphereConsole, fake_sleep):
+        """``configure_new_8_1_cluster`` returns None"""
+        fake_logger = MagicMock()
+        output = setup_onefs.configure_new_8_1_cluster(logger=fake_logger,
+                                                       console_url='https://someHTMLconsole.com',
+                                                       cluster_name='mycluster',
+                                                       int_netmask='255.255.255.0',
+                                                       int_ip_low='8.6.7.5',
+                                                       int_ip_high='8.6.7.50',
+                                                       ext_netmask='255.255.255.0',
+                                                       ext_ip_low='3.0.9.2',
+                                                       ext_ip_high='3.0.9.20',
+                                                       gateway='3.0.9.1',
+                                                       dns_servers='1.1.1.1',
+                                                       encoding='utf-8',
+                                                       sc_zonename='myzone.foo.org',
+                                                       smartconnect_ip='3.0.9.21')
+        expected = None
+
+        self.assertEqual(output, expected)
+
+    def test_configure_new_8_1_2_cluster(self, fake_vSphereConsole, fake_sleep):
+        """``configure_new_8_1_2_cluster`` returns None"""
+        fake_logger = MagicMock()
+        output = setup_onefs.configure_new_8_1_2_cluster(logger=fake_logger,
+                                                       console_url='https://someHTMLconsole.com',
+                                                       cluster_name='mycluster',
+                                                       int_netmask='255.255.255.0',
+                                                       int_ip_low='8.6.7.5',
+                                                       int_ip_high='8.6.7.50',
+                                                       ext_netmask='255.255.255.0',
+                                                       ext_ip_low='3.0.9.2',
+                                                       ext_ip_high='3.0.9.20',
+                                                       gateway='3.0.9.1',
+                                                       dns_servers='1.1.1.1',
+                                                       encoding='utf-8',
+                                                       sc_zonename='myzone.foo.org',
+                                                       smartconnect_ip='3.0.9.21')
+        expected = None
+
+        self.assertEqual(output, expected)
+
+    @patch.object(setup_onefs, 'set_esrs')
+    def test_configure_new_8_1_2_cluster_esrs(self, fake_set_esrs, fake_vSphereConsole, fake_sleep):
+        """``configure_new_8_1_2_cluster`` does not config ESRS"""
+        fake_logger = MagicMock()
+        setup_onefs.configure_new_8_1_2_cluster(logger=fake_logger,
+                                                console_url='https://someHTMLconsole.com',
+                                                cluster_name='mycluster',
+                                                int_netmask='255.255.255.0',
+                                                int_ip_low='8.6.7.5',
+                                                int_ip_high='8.6.7.50',
+                                                ext_netmask='255.255.255.0',
+                                                ext_ip_low='3.0.9.2',
+                                                ext_ip_high='3.0.9.20',
+                                                gateway='3.0.9.1',
+                                                dns_servers='1.1.1.1',
+                                                encoding='utf-8',
+                                                sc_zonename='myzone.foo.org',
+                                                smartconnect_ip='3.0.9.21')
+        called = fake_set_esrs.call_count
+        expected = 0
+
+        self.assertEqual(called, expected)
+
+
+class TestWizardRoutines(unittest.TestCase):
+    """
+    A set of test cases for the functions that handle a specific part of the
+    OneFS configuration wizard.
+    """
+    @classmethod
+    def setUp(cls):
+        cls.fake_console = MagicMock()
+
+    @patch.object(setup_onefs.time, 'sleep')
+    def test_format_disks(self, fake_sleep):
+        """``format_disks`` returns None"""
+        output = setup_onefs.format_disks(self.fake_console)
+        expected = None
+
+        self.assertEqual(output, expected)
+
+    @patch.object(setup_onefs.time, 'sleep')
+    def test_format_disks(self, fake_sleep):
+        """``format_disks`` blocks while the disks format"""
+        setup_onefs.format_disks(self.fake_console)
+
+        args, _ = fake_sleep.call_args
+        expected = (setup_onefs.FORMAT_WAIT,)
+
+        self.assertEqual(args, expected)
+
+    def test_make_new_and_accept_eual(self):
+        """``make_new_and_accept_eual`` returns None"""
+        output = setup_onefs.make_new_and_accept_eual(self.fake_console)
+        expected = None
+
+        self.assertEqual(output, expected)
+
+    def test_set_passwords(self):
+        """``set_passwords`` returns None"""
+        output = setup_onefs.set_passwords(self.fake_console)
+        expected = None
+
+        self.assertEqual(output, expected)
+
+    def test_set_esrs(self):
+        """``set_esrs`` returns None"""
+        output = setup_onefs.set_esrs(self.fake_console)
+        expected = None
+
+        self.assertEqual(output, expected)
+
+    def test_set_name(self):
+        """``set_esrs`` returns None"""
+        output = setup_onefs.set_name(self.fake_console, 'mycluster')
+        expected = None
+
+        self.assertEqual(output, expected)
+
+    def test_set_encoding(self):
+        """``set_encoding`` returns None"""
+        output = setup_onefs.set_encoding(self.fake_console, 'utf-8')
+        expected = None
+
+        self.assertEqual(output, expected)
+
+    def test_config_network(self):
+        """``config_network`` returns None"""
+        output = setup_onefs.config_network(self.fake_console,
+                                            netmask='255.255.255.0',
+                                            ip_low='2.2.2.2',
+                                            ip_high='2.2.2.20')
+        expected = None
+
+        self.assertEqual(output, expected)
+
+    def test_set_default_gateway(self):
+        """``set_default_gateway`` returns None"""
+        output = setup_onefs.set_default_gateway(self.fake_console, '2.2.2.1')
+        expected = None
+
+        self.assertEqual(output, expected)
+
+    def test_set_smartconnect(self):
+        """``set_smartconnect`` returns None"""
+        output = setup_onefs.set_smartconnect(self.fake_console,
+                                              sc_zonename='myzone.foo.com',
+                                              smartconnect_ip='3.3.3.3')
+        expected = None
+
+        self.assertEqual(output, expected)
+
+    def test_set_smartconnect_zone_name_optional(self):
+        """``set_smartconnect`` setting the SmartConnect zone name is optional"""
+        output = setup_onefs.set_smartconnect(self.fake_console,
+                                              smartconnect_ip='3.3.3.3')
+        expected = None
+
+        self.assertEqual(output, expected)
+
+    def test_set_smartconnect_sip_optional(self):
+        """``set_smartconnect`` setting the SmartConnect IP is optional"""
+        output = setup_onefs.set_smartconnect(self.fake_console,
+                                              sc_zonename='myzone.foo.com')
+        expected = None
+
+        self.assertEqual(output, expected)
+
+    def test_set_smartconnect_all_optional(self):
+        """``set_smartconnect`` All smartconnect settings are skipped if not supplied"""
+        setup_onefs.set_smartconnect(self.fake_console)
+
+        call_count = self.fake_console.send_keys.call_count
+        expected = 1
+
+        self.assertEqual(call_count, expected)
+
+    def test_set_dns(self):
+        """``set_dns`` returns None"""
+        output = setup_onefs.set_dns(self.fake_console, dns_servers='1.1.1.1')
+
+        expected = None
+
+        self.assertEqual(output, expected)
+
+    def test_set_timezone(self):
+        """``set_timezone`` returns None"""
+        output = setup_onefs.set_timezone(self.fake_console)
+
+        expected = None
+
+        self.assertEqual(output, expected)
+
+    def test_set_join_mode(self):
+        """``set_join_mode`` returns None"""
+        output = setup_onefs.set_join_mode(self.fake_console)
+
+        expected = None
+
+        self.assertEqual(output, expected)
+
+    def test_commit_config(self):
+        """``commit_config`` returns None"""
+        output = setup_onefs.commit_config(self.fake_console)
+
+        expected = None
+
+        self.assertEqual(output, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -88,6 +88,90 @@ class TestTasks(unittest.TestCase):
 
         self.assertEqual(output, expected)
 
+    @patch.object(tasks, 'vmware')
+    @patch.object(tasks, 'setup_onefs')
+    def test_config(self, fake_setup_onefs, fake_vmware):
+        """``config`` returns a dictionary upon success"""
+        fake_vmware.show_onefs.return_value = {'mycluster-1' : {'console': 'https://htmlconsole.com'}}
+
+        output = tasks.config(cluster_name='mycluster',
+                              name='mycluster-1',
+                              username='bob',
+                              version='8.1.1.0',
+                              int_netmask='255.255.255.0',
+                              int_ip_low='5.5.5.1',
+                              int_ip_high='5.5.5.10',
+                              ext_netmask='255.255.255.0',
+                              ext_ip_low='10.1.1.2',
+                              ext_ip_high='10.1.1.20',
+                              gateway='10.1.1.1',
+                              dns_servers='1.1.1.1,8.8.8.8',
+                              encoding='utf-8',
+                              sc_zonename='myzone.foo.com',
+                              smartconnect_ip='10.1.1.21',
+                              join_cluster=False)
+        expected = {'content': {}, 'error': None, 'params': {}}
+
+        self.assertEqual(output, expected)
+
+    @patch.object(tasks, 'vmware')
+    @patch.object(tasks, 'setup_onefs')
+    def test_config_join(self, fake_setup_onefs, fake_vmware):
+        """``config`` returns a dictionary upon joining a node to an existing cluster"""
+        fake_vmware.show_onefs.return_value = {'mycluster-1' : {'console': 'https://htmlconsole.com'}}
+
+        output = tasks.config(cluster_name='mycluster',
+                              name='mycluster-1',
+                              username='bob',
+                              version='8.1.1.0',
+                              int_netmask='255.255.255.0',
+                              int_ip_low='5.5.5.1',
+                              int_ip_high='5.5.5.10',
+                              ext_netmask='255.255.255.0',
+                              ext_ip_low='10.1.1.2',
+                              ext_ip_high='10.1.1.20',
+                              gateway='10.1.1.1',
+                              dns_servers='1.1.1.1,8.8.8.8',
+                              encoding='utf-8',
+                              sc_zonename='myzone.foo.com',
+                              smartconnect_ip='10.1.1.21',
+                              join_cluster=True)
+        expected = {'content': {}, 'error': None, 'params': {}}
+
+        self.assertEqual(output, expected)
+
+    @patch.object(tasks, 'vmware')
+    @patch.object(tasks, 'setup_onefs')
+    def test_config_no_node(self, fake_setup_onefs, fake_vmware):
+        """``config`` returns an error if unable to find the node to configure"""
+        fake_vmware.show_onefs.return_value = {}
+
+        output = tasks.config(cluster_name='mycluster',
+                              name='mycluster-1',
+                              username='bob',
+                              version='8.1.1.0',
+                              int_netmask='255.255.255.0',
+                              int_ip_low='5.5.5.1',
+                              int_ip_high='5.5.5.10',
+                              ext_netmask='255.255.255.0',
+                              ext_ip_low='10.1.1.2',
+                              ext_ip_high='10.1.1.20',
+                              gateway='10.1.1.1',
+                              dns_servers='1.1.1.1,8.8.8.8',
+                              encoding='utf-8',
+                              sc_zonename='myzone.foo.com',
+                              smartconnect_ip='10.1.1.21',
+                              join_cluster=False)
+        expected = {'content': {}, 'error': 'No node named mycluster-1 found', 'params': {}}
+
+        self.assertEqual(output, expected)
+
+
+
+
+
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,215 @@
+# -*- coding: UTF-8 -*-
+"""
+A suite of tests for the validators.py module
+"""
+import unittest
+
+from vlab_onefs_api.lib import validators
+
+
+class TestValidaters(unittest.TestCase):
+    """A suite of test cases for the different input validators for /config"""
+    def test_to_network(self):
+        """``to_network`` returns ipaddress.IPv4Network object"""
+        output = validators.to_network('192.168.1.1', netmask='255.255.255.0')
+        expected = validators.ipaddress.IPv4Network('192.168.1.0/24')
+
+        self.assertEqual(output, expected)
+
+    def test_validate_ip_range_ok(self):
+        """``validate_ip_range`` - returns None when ip_high bigger than ip_low"""
+        output = validators.validate_ip_range(ip_low='1.1.1.1', ip_high='2.2.2.2', group='internal network')
+        expected = None
+
+        self.assertEqual(output, expected)
+
+    def test_validate_ip_range_raises(self):
+        """``validate_ip_range`` - Raises ValueError when ip_low bigger than ip_high"""
+        with self.assertRaises(ValueError):
+            validators.validate_ip_range(ip_low='8.1.1.1', ip_high='2.2.2.2', group='internal network')
+
+    def test_validate_ext_network(self):
+        """``validate_ext_network`` returns None when network is valid"""
+        output = validators.validate_ext_network(netmask='255.255.255.0',
+                                                 ext_ip_low='192.168.1.20',
+                                                 ext_ip_high='192.168.1.30',
+                                                 smartconnect_ip='192.168.1.31',
+                                                 gateway='192.168.1.1')
+        expected = None
+
+        self.assertEqual(output, expected)
+
+    def test_validate_ext_network_smartconnect_ip_optional(self):
+        """``validate_ext_network`` the smartconnect_ip param is optional"""
+        output = validators.validate_ext_network(netmask='255.255.255.0',
+                                                 ext_ip_low='192.168.1.20',
+                                                 ext_ip_high='192.168.1.30',
+                                                 smartconnect_ip='',
+                                                 gateway='192.168.1.1')
+        expected = None
+
+        self.assertEqual(output, expected)
+
+    def test_validate_ext_network_bad_network(self):
+        """``validate_ext_network`` raises ValueError if the gateway and mask are junk"""
+        with self.assertRaises(ValueError):
+            validators.validate_ext_network(netmask='255.253.255.0',
+                                            ext_ip_low='192.168.1.20',
+                                            ext_ip_high='192.168.1.30',
+                                            smartconnect_ip='192.168.1.31',
+                                            gateway='192.1.1.1')
+
+    def test_validate_ext_network_bad_ext_low(self):
+        """``validate_ext_network`` raises ValueError if ext_low is not in the network"""
+        with self.assertRaises(ValueError):
+            validators.validate_ext_network(netmask='255.255.255.0',
+                                       ext_ip_low='192.1.1.20',
+                                       ext_ip_high='192.168.1.30',
+                                       smartconnect_ip='192.168.1.31',
+                                       gateway='192.168.1.1')
+
+    def test_validate_ext_network_bad_ext_high(self):
+        """``validate_ext_network`` raises ValueError if ext_high is not in the network"""
+        with self.assertRaises(ValueError):
+            validators.validate_ext_network(netmask='255.255.255.0',
+                                            ext_ip_low='192.168.1.20',
+                                            ext_ip_high='192.1.1.30',
+                                            smartconnect_ip='192.168.1.31',
+                                            gateway='192.168.1.1')
+
+    def test_validate_ext_network_bad_smartconnect_ip(self):
+        """``validate_ext_network`` raises ValueError if smartconnect_ip is not in the network"""
+        with self.assertRaises(ValueError):
+            validators.validate_ext_network(netmask='255.255.255.0',
+                                            ext_ip_low='192.168.1.20',
+                                            ext_ip_high='192.168.1.30',
+                                            smartconnect_ip='192.1.1.31',
+                                            gateway='192.168.1.1')
+
+    def test_validate_names(self):
+        """``validate_names`` returns None upon success"""
+        output = validators.validate_names('mycluster', group='cluster name')
+        expected = None
+
+        self.assertEqual(output, expected)
+
+    def test_validate_names_too_long(self):
+        """``validate_names`` raises ValueError if the hostname is too long"""
+        with self.assertRaises(ValueError):
+            validators.validate_names('-'.join(['a' for x in range(300)]),
+                                      group='cluster name')
+
+    def test_validate_names_bad_name(self):
+        """``validate_names`` raises ValueError if the hostname contains invalid chars"""
+        with self.assertRaises(ValueError):
+            validators.validate_names(hostname='1sdf.foo', group='cluster name')
+
+    def test_validate_names_bad_char(self):
+        """``validate_names`` raises ValueError if the hostname contains invalid chars"""
+        with self.assertRaises(ValueError):
+            validators.validate_names(hostname='sdf.foo_bar.com', group='cluster name')
+
+    def test_validate_ips(self):
+        """``validate_ips`` returns None upon success"""
+        output = validators.validate_ips('192.168.1.1', '10.7.1.2', group='front end network')
+        expected = None
+
+        self.assertEqual(output, expected)
+
+    def test_validate_ips_raises(self):
+        """``validate_ips`` raises ValueError if supplied with not an IP address"""
+        with self.assertRaises(ValueError):
+            validators.validate_ips('a.b.c.d', group='internal network')
+
+    def test_validate_ips_ipv6(self):
+        """``validate_ips`` raises ValueError if supplied with an IPv6 address"""
+        with self.assertRaises(ValueError):
+            validators.validate_ips('dead::beef', group='internal network')
+
+    def test_validate_netmask(self):
+        """``validate_netmask`` returns None upon success"""
+        output = validators.validate_netmask('255.255.255.0', group='backend network')
+        expected = None
+
+        self.assertEqual(output, expected)
+
+    def test_validate_netmask_raises(self):
+        """``validate_netmask`` raises ValueError if supplied with an invalid subnet mask"""
+        with self.assertRaises(ValueError):
+            validators.validate_netmask('255.2.255.0', group='backend network')
+
+    def test_validate_netmask_bit_zero(self):
+        """``validate_netmask`` raises ValueError supplied subnet mask starts with bit zero"""
+        with self.assertRaises(ValueError):
+            validators.validate_netmask('0.2.255.0', group='backend network')
+
+    def test_supplied_config_values_are_valid(self):
+        """``supplied_config_values_are_valid`` Returns an empty string upon success"""
+        error_msg = validators.supplied_config_values_are_valid(cluster_name='mycluster',
+                                                                int_netmask='255.255.255.0',
+                                                                int_ip_low='2.2.2.1',
+                                                                int_ip_high='2.2.2.10',
+                                                                ext_netmask='255.255.255.0',
+                                                                ext_ip_low='10.1.1.2',
+                                                                ext_ip_high='10.1.1.20',
+                                                                dns_servers='1.1.1.1,8.8.8.8',
+                                                                sc_zonename='myzone.foo.com',
+                                                                smartconnect_ip='10.1.1.21',
+                                                                gateway='10.1.1.1',
+                                                                join_cluster=False)
+        expected = ''
+        self.assertEqual(error_msg, expected)
+
+    def test_supplied_config_values_are_valid_join(self):
+        """``supplied_config_values_are_valid`` Can successfully parse required values for a node to join a cluster"""
+        error_msg = validators.supplied_config_values_are_valid(cluster_name='mycluster',
+                                                                int_netmask='',
+                                                                int_ip_low='',
+                                                                int_ip_high='',
+                                                                ext_netmask='',
+                                                                ext_ip_low='',
+                                                                ext_ip_high='',
+                                                                dns_servers='',
+                                                                sc_zonename='',
+                                                                smartconnect_ip='',
+                                                                gateway='',
+                                                                join_cluster=True)
+        expected = ''
+        self.assertEqual(error_msg, expected)
+
+    def test_supplied_config_values_are_valid_join_error(self):
+        """``supplied_config_values_are_valid`` Returns an error message if the join_cluster values are bad"""
+        error_msg = validators.supplied_config_values_are_valid(cluster_name='mycluster.foo_bar.org',
+                                                                int_netmask='',
+                                                                int_ip_low='',
+                                                                int_ip_high='',
+                                                                ext_netmask='',
+                                                                ext_ip_low='',
+                                                                ext_ip_high='',
+                                                                dns_servers='',
+                                                                sc_zonename='',
+                                                                smartconnect_ip='',
+                                                                gateway='',
+                                                                join_cluster=True)
+        expected = 'Invalid name of mycluster.foo_bar.org supplied for cluster name'
+        self.assertEqual(error_msg, expected)
+
+    def test_supplied_config_values_are_valid_bad_value(self):
+        """``supplied_config_values_are_valid`` Returns an error message if any input is invalid"""
+        error_msg = validators.supplied_config_values_are_valid(cluster_name='mycluster',
+                                                                int_netmask='255.255.255.0',
+                                                                int_ip_low='2.2.3.1',
+                                                                int_ip_high='2.2.2.10',
+                                                                ext_netmask='255.255.255.0',
+                                                                ext_ip_low='10.1.1.2',
+                                                                ext_ip_high='10.1.1.20',
+                                                                dns_servers='1.1.1.1,8.8.8.8',
+                                                                sc_zonename='myzone.foo.com',
+                                                                smartconnect_ip='10.1.1.21',
+                                                                gateway='10.1.1.1',
+                                                                join_cluster=False)
+        expected = 'IP 2.2.3.1 larger than top of IP range 2.2.2.10 for the internal network'
+        self.assertEqual(error_msg, expected)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vlab_onefs_api/lib/constants.py
+++ b/vlab_onefs_api/lib/constants.py
@@ -23,6 +23,9 @@ DEFINED = OrderedDict([
             ('VLAB_MESSAGE_BROKER', environ.get('VLAB_MESSAGE_BROKER', 'onefs-broker')),
             ('VLAB_URL', environ.get('VLAB_URL', 'https://localhost')),
             ('VLAB_ONEFS_IMAGES_DIR', environ.get('VLAB_ONEFS_IMAGES_DIR', '/images')),
+            ('INF_VCENTER_READONLY_USER', environ.get('INF_VCENTER_READONLY_USER', 'readonly@vsphere.local')),
+            ('INF_VCENTER_READONLY_PASSWORD', environ.get('INF_VCENTER_READONLY_PASSWORD', 'a')),
+            ('VLAB_VERIFY_TOKEN', environ.get('VLAB_VERIFY_TOKEN', False)),
           ])
 
 Constants = namedtuple('Constants', list(DEFINED.keys()))

--- a/vlab_onefs_api/lib/validators.py
+++ b/vlab_onefs_api/lib/validators.py
@@ -1,0 +1,192 @@
+# -*- coding: UTF-8 -*-
+"""This module contains functions for validating user input"""
+import re
+import ipaddress
+
+
+def supplied_config_values_are_valid(int_netmask, int_ip_low, int_ip_high, ext_netmask,
+                                     ext_ip_low, ext_ip_high, gateway, cluster_name,
+                                     sc_zonename, smartconnect_ip, dns_servers, join_cluster):
+    """Additional input validation for OneFS config parameters.
+
+    :Returns: String
+
+    :param cluster_name: The name to give the new cluster
+    :type cluster_name: String
+
+    :param int_netmask: The subnet mask for the internal OneFS network
+    :type int_netmask: String
+
+    :param int_ip_low: The smallest IP to assign to an internal NIC
+    :type int_ip_low: String (IPv4 address)
+
+    :param int_ip_high: The largest IP to assign to an internal NIC
+    :type int_ip_high: String (IPv4 address)
+
+    :param ext_ip_low: The smallest IP to assign to an external/public NIC
+    :type ext_ip_low: String (IPv4 address)
+
+    :param ext_ip_high: The largest IP to assign to an external/public NIC
+    :type ext_ip_high: String (IPv4 address)
+
+    :param gateway: The IP address for the default gateway
+    :type gateway: String (IPv4 address)
+
+    :param dns_servers: A common separated list of IPs of the DNS servers to use
+    :type dns_servers: String
+
+    :param sc_zonename: The SmartConnect Zone name to use. Skipped if None.
+    :type sc_zonename: String
+
+    :param smartconnect_ip: The IPv4 address to use as the SIP
+    :type smartconnect_ip: String (IPv4 address)
+
+    :param join_cluster: Set to True to only validate input for joining an existing cluster
+    :type join_cluster: Boolean
+    """
+    error = ''
+    if join_cluster:
+        try:
+            validate_names(cluster_name, group='cluster name')
+        except ValueError as doh:
+            error = str(doh)
+    else:
+        try:
+            validate_netmask(int_netmask, group='internal')
+            validate_netmask(ext_netmask, group='external')
+            validate_ips(int_ip_low, int_ip_high, group='the internal network')
+            validate_ips(ext_ip_low, ext_ip_high, group='the external network')
+            validate_ip_range(int_ip_low, int_ip_high, group='the internal network')
+            validate_ip_range(ext_ip_low, ext_ip_high, group='the external network')
+            for dns_ip in dns_servers.split(','):
+                validate_ips(dns_ip, group='DNS')
+            if smartconnect_ip:
+                validate_ips(smartconnect_ip, group='smartconnect')
+            validate_ext_network(ext_netmask, ext_ip_low, ext_ip_high, smartconnect_ip, gateway)
+            validate_names(cluster_name, group='cluster name')
+            if sc_zonename:
+                validate_names(cluster_name, group='SmartConnect Zone name')
+        except ValueError as doh:
+            error = '{}'.format(doh)
+    return error
+
+
+def validate_netmask(mask, group):
+    """Ensure the subnet mask supplied is valid.
+
+    A valid subnet mask will be bit values 1 to define what's "not local." In the
+    32 bits that make an IPv4 address, once the mask is defined, only a bit value
+    of 0 is valid. I.E. once you go zero, you never go back to one.
+
+    :Returns: None
+
+    :Raises: ValueError
+    """
+    try:
+        octets = [int(x) for x in mask.split('.')]
+        last_bit = None
+        for octet in octets:
+            bits = bin(octet)[2:] # strip of the 0b part...
+            for bit in bits:
+                if last_bit is None:
+                    if bit != '1':
+                        raise ValueError('Netmask must begin with bit 1')
+                    else:
+                        last_bit = bit
+                elif (bit != last_bit) and bit == '1':
+                    raise ValueError('Netmask cannot contain bit value 1 after zero')
+                else:
+                    last_bit = bit
+    except ValueError:
+        error = 'Invalid Subnet {} supplied for the {} network'.format(mask, group)
+        raise ValueError(error)
+
+
+def validate_ips(*args, group=None):
+    """Ensure the supplied IPs are IPv4 addresses
+
+    :Returns: None
+
+    :Raises: ValueError
+    """
+    for ip in args:
+        try:
+            ipaddress.IPv4Address(ip)
+        except ipaddress.AddressValueError:
+            error = 'Supplied IP {} is not a valid IPv4 address for {}'.format(ip, group)
+            raise ValueError(error)
+
+
+def validate_names(hostname, group):
+    """Ensure the supplied name is a valid hostname https://tools.ietf.org/html/rfc1123
+
+    :Returns: None
+
+    :Raises: ValueError
+    """
+    ok = True
+    allowed = re.compile("(?!-)[A-Z\d-]{1,63}(?<!-)$", re.IGNORECASE)
+    hostname = hostname.rstrip('.') # remove any trailing dot
+    try:
+        int(hostname[0])
+        ok = False # hostname cannot start with a number
+    except ValueError:
+        if len(hostname) > 253 or len(hostname) < 1:
+            ok = False
+        elif not all(allowed.match(x) for x in hostname.split(".")):
+            ok = False
+    if not ok:
+        error = 'Invalid name of {} supplied for {}'.format(hostname, group)
+        raise ValueError(error)
+
+
+def validate_ext_network(netmask, ext_ip_low, ext_ip_high, smartconnect_ip, gateway):
+    """Ensure the supplied external network subnet and ips are OK
+
+    :Returns: None
+
+    :Raises: ValueError
+    """
+    error = ''
+    # default gateway must within supplied subnet, so lets assume that is the network
+    try:
+        network = list(to_network(gateway, netmask))
+    except Exception:
+        error = 'Default gateway {} not part of subnet {}'.format(gateway, netmask)
+        raise ValueError(error)
+    if not ipaddress.IPv4Address(ext_ip_low) in network:
+        error = 'Ext IP {} not part of network {}'.format(ext_ip_low, network)
+    elif not ipaddress.IPv4Address(ext_ip_high) in network:
+        error = 'Ext IP {} not part of network {}'.format(ext_ip_low, network)
+    elif smartconnect_ip:
+        # skipping config of SmartConnect is OK
+        if not ipaddress.IPv4Address(smartconnect_ip) in network:
+            error = 'SmartConnect IP {} not part of network {}'.format(smartconnect_ip, network)
+    if error:
+        raise ValueError(error)
+
+
+def validate_ip_range(ip_low, ip_high, group):
+    """Ensure the bottom of the IP range comes after the top of the IP range
+
+    :Returns: None
+
+    :Raises: ValueError
+    """
+    if not ip_low <= ip_high:
+        error = 'IP {} larger than top of IP range {} for {}'.format(ip_low, ip_high, group)
+        raise ValueError(error)
+
+
+def to_network(ip, netmask):
+    """Convert an IP and subnet mask into CIDR format
+
+    :Returns: ipaddress.IPv4Network
+    """
+    ipaddr = ip.split('.')
+    mask = netmask.split('.')
+    # to calculate network start do a bitwise AND of the octets between netmask and ip
+    net_start = '.'.join([str(int(ipaddr[x]) & int(mask[x])) for x in range(4)])
+    bit_count = sum([bin(int(x)).count("1") for x in netmask.split('.')])
+    cidr = '{}/{}'.format(net_start, bit_count)
+    return ipaddress.IPv4Network(cidr)

--- a/vlab_onefs_api/lib/views/onefs.py
+++ b/vlab_onefs_api/lib/views/onefs.py
@@ -2,6 +2,10 @@
 """
 Defines the RESTful HTTP API for the OneFS service
 """
+import re
+import ipaddress
+from socket import inet_aton
+
 import ujson
 from flask import current_app
 from flask_classy import request, route, Response
@@ -11,6 +15,7 @@ from vlab_api_common import describe, get_logger, requires, validate_input
 
 
 from vlab_onefs_api.lib import const
+from vlab_onefs_api.lib.validators import supplied_config_values_are_valid
 
 
 logger = get_logger(__name__, loglevel=const.VLAB_ONEFS_LOG_LEVEL)
@@ -62,8 +67,101 @@ class OneFSView(TaskView):
     IMAGES_SCHEMA = {"$schema": "http://json-schema.org/draft-04/schema#",
                      "description": "View available versions of vOneFS that can be created"
                     }
+    CONFIG_SCHEMA = {"$schema": "http://json-schema.org/draft-04/schema#",
+                     "description": "Configure a OneFS node",
+                     "type": "object",
+                     "properties": {
+                        "cluster_name": {
+                            "description": "The name of the OneFS cluster to create/join",
+                            "type": "string"
+                        },
+                        "name": {
+                            "description" : "The name of the OneFS node to configure",
+                            "type": "string"
+                        },
+                        "join": {
+                            "description": "Join node to an existing cluster",
+                            "type": "boolean"
+                        },
+                        "version" : {
+                            "description" : "The version of OneFS being configured (the config wizard changes with versions)",
+                            "type": "string"
+                        },
+                        "ext_ip_high": {
+                            "description": "The top of the IP range of the external network to allocate to the cluster",
+                            "type": "string"
+                        },
+                        "ext_ip_low": {
+                            "description": "The bottom of the IP range of the external network to allocate to the cluster",
+                            "type": "string"
+                        },
+                        "ext_netmask": {
+                            "description": "The subnet mask to give the external network",
+                            "type": "string"
+                        },
+                        "int_ip_high": {
+                            "description": "The top of the IP range of the internal network to allocate to the cluster",
+                            "type": "string"
+                        },
+                        "int_ip_low": {
+                            "description": "The bottom of the IP range of the internal network to allocate to the cluster",
+                            "type": "string"
+                        },
+                        "int_netmask": {
+                            "description": "The subnet mask to give the internal network",
+                            "type": "string"
+                        },
+                        "gateway": {
+                            "description": "The default gateway to use on the external network",
+                            "type": "string"
+                        },
+                        "dns_servers": {
+                            "description": "The DNS servers to configure on the EXT network",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "sc_zonename": {
+                            "description": "The name of the SmartConnect Zone name. Empty string is valid",
+                            "type": "string"
+                        },
+                        "smartconnect_ip": {
+                            "description": "The SIP to configure on the external network. Empty string is valid",
+                            "type": "string"
+                        },
+                        "encoding": {
+                            "description": "The filesystem encoding to use.",
+                            "type": "string",
+                            "enum": ['windows-sjis', 'windows-949', 'windows-1252',
+                                     'euc-kr', 'euc-jp', 'euc-jp-ms', 'utf-8-mac',
+                                     'utf-8', 'latin-1', 'latin-2', 'latin-3',
+                                     'latin-4', 'cyrillic', 'arabic', 'greek',
+                                     'hebrew', 'latin-5', 'latin-6', 'latin-7',
+                                     'latin-8', 'latin-9', 'latin-10']
+                        }
 
-    @requires(verify=False, version=(1,2))
+                     },
+                     "oneOf": [
+                        {"required": ["name", "cluster_name", "join"],
+                         "not": {"required": ["ext_ip_high", "ext_ip_low", "ext_netmask",
+                                              "int_ip_high", "int_ip_low", "int_netmask",
+                                              "dns_servers", "sc_zonename", "smartconnect_ip",
+                                              "encoding", "version"
+                                              ]
+                                }
+                        },
+                        {"required": ["name", "cluster_name", "encoding", "version",
+                                      "ext_ip_high","ext_ip_low", "ext_netmask",
+                                      "int_ip_high", "int_ip_low", "int_netmask",
+                                      "dns_servers", "sc_zonename", "smartconnect_ip",
+                                      ],
+                         "not": {"required": ["join"]}
+                        }
+                     ]
+                    }
+
+    @requires(verify=const.VLAB_VERIFY_TOKEN, version=(1,2))
     @describe(post=POST_SCHEMA, delete=DELETE_SCHEMA, get_args=GET_SCHEMA)
     def get(self, *args, **kwargs):
         """Display the vOneFS nodes you own"""
@@ -76,7 +174,7 @@ class OneFSView(TaskView):
         resp.headers.add('Link', '<{0}{1}/task/{2}>; rel=status'.format(const.VLAB_URL, self.route_base, task.id))
         return resp
 
-    @requires(verify=False, version=(1,2)) # XXX remove verify=False before commit
+    @requires(verify=const.VLAB_VERIFY_TOKEN, version=(1,2)) # XXX remove verify=False before commit
     @validate_input(schema=POST_SCHEMA)
     def post(self, *args, **kwargs):
         """Create a new vOneFS node"""
@@ -92,9 +190,10 @@ class OneFSView(TaskView):
         resp = Response(ujson.dumps(resp_data))
         resp.status_code = 202
         resp.headers.add('Link', '<{0}{1}/task/{2}>; rel=status'.format(const.VLAB_URL, self.route_base, task.id))
+        resp.headers.add('Link', '<{0}{1}/config>; rel=config>'.format(const.VLAB_URL, self.route_base))
         return resp
 
-    @requires(verify=False, version=(1,2)) # XXX remove verify=False before commit
+    @requires(verify=const.VLAB_VERIFY_TOKEN, version=(1,2)) # XXX remove verify=False before commit
     @validate_input(schema=DELETE_SCHEMA)
     def delete(self, *args, **kwargs):
         """Destroy a vOneFS node"""
@@ -109,7 +208,7 @@ class OneFSView(TaskView):
         return resp
 
     @route('/image', methods=["GET"])
-    @requires(verify=False, version=(1,2))
+    @requires(verify=const.VLAB_VERIFY_TOKEN, version=(1,2))
     @describe(get=IMAGES_SCHEMA)
     def image(self, *args, **kwargs):
         """Show available versions of OneFS that can be deployed"""
@@ -120,4 +219,72 @@ class OneFSView(TaskView):
         resp = Response(ujson.dumps(resp_data))
         resp.status_code = 202
         resp.headers.add('Link', '<{0}{1}/task/{2}>; rel=status'.format(const.VLAB_URL, self.route_base, task.id))
+        return resp
+
+    @route('/config', methods=["POST"])
+    @requires(verify=const.VLAB_VERIFY_TOKEN, version=2)
+    @describe(post=CONFIG_SCHEMA)
+    @validate_input(schema=CONFIG_SCHEMA)
+    def config(self, *args, **kwargs):
+        """Set the configuration of a OneFS node"""
+        status_code = 202
+        username = kwargs['token']['username']
+        resp_data = {'user' : username}
+        # Aligning these just makes it easier to read
+        cluster_name    = kwargs['body']['cluster_name']
+        name            = kwargs['body']['name']
+        version         = kwargs['body'].get('version', None)
+        int_netmask     = kwargs['body'].get('int_netmask', None)
+        int_ip_low      = kwargs['body'].get('int_ip_low', None)
+        int_ip_high     = kwargs['body'].get('int_ip_high', None)
+        ext_netmask     = kwargs['body'].get('ext_netmask', None)
+        ext_ip_low      = kwargs['body'].get('ext_ip_low', None)
+        ext_ip_high     = kwargs['body'].get('ext_ip_high', None)
+        gateway         = kwargs['body'].get('gateway', None)
+        encoding        = kwargs['body'].get('encoding', None)
+        sc_zonename     = kwargs['body'].get('sc_zonename', None)
+        smartconnect_ip = kwargs['body'].get('smartconnect_ip', None)
+        join_cluster    = kwargs['body'].get('join', False)
+        dns_servers     = ','.join(kwargs['body'].get('dns_servers', []))
+        # Ensure supplied values wont generate an error in the OneFS config wizard
+        error = supplied_config_values_are_valid(int_netmask=int_netmask,
+                                                 int_ip_low=int_ip_low,
+                                                 int_ip_high=int_ip_high,
+                                                 ext_netmask=ext_netmask,
+                                                 ext_ip_low=ext_ip_low,
+                                                 ext_ip_high=ext_ip_high,
+                                                 gateway=gateway,
+                                                 cluster_name=cluster_name,
+                                                 sc_zonename=sc_zonename,
+                                                 smartconnect_ip=smartconnect_ip,
+                                                 dns_servers=dns_servers,
+                                                 join_cluster=join_cluster)
+        if error:
+            resp_data['error'] = error
+            status_code = 400
+            link = None
+        else:
+            task = current_app.celery_app.send_task('onefs.config', kwargs={'cluster_name' : cluster_name,
+                                                                            'name' : name,
+                                                                            'username' : username,
+                                                                            'version' : version,
+                                                                            'int_netmask' : int_netmask,
+                                                                            'int_ip_low' : int_ip_low,
+                                                                            'int_ip_high' : int_ip_high,
+                                                                            'ext_netmask' : ext_netmask,
+                                                                            'ext_ip_low' : ext_ip_low,
+                                                                            'ext_ip_high' : ext_ip_high,
+                                                                            'gateway' : gateway,
+                                                                            'dns_servers' : dns_servers,
+                                                                            'encoding' : encoding,
+                                                                            'sc_zonename' : sc_zonename,
+                                                                            'smartconnect_ip' : smartconnect_ip,
+                                                                            'join_cluster' : join_cluster})
+
+            resp_data['content'] = {'task-id': task.id}
+            link = '<{0}{1}/task/{2}>; rel=status'.format(const.VLAB_URL, self.route_base, task.id)
+        resp = Response(ujson.dumps(resp_data))
+        resp.status_code = status_code
+        if link:
+            resp.headers.add('Link', link)
         return resp

--- a/vlab_onefs_api/lib/worker/setup_onefs.py
+++ b/vlab_onefs_api/lib/worker/setup_onefs.py
@@ -1,0 +1,497 @@
+# -*- coding: UTF-8 -*-
+"""This module encapsulates configuring a OneFS node"""
+import time
+
+from selenium import webdriver
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.common.by import By
+from selenium.webdriver.firefox.options import Options
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
+from vlab_onefs_api.lib import const
+
+
+BOOT_WAIT = 60   # dumb sleep while waiting for the node to fully boot
+FORMAT_WAIT = 90 # dumb sleep waiting for the new VMDKs for format
+BUILD_WAIT = 90  # dumb sleep while OneFS applies the new config
+
+
+class vSphereConsole(object):
+    """Login and return an interactive session with the HTML console for a VM"""
+    def __init__(self, url, username=const.INF_VCENTER_READONLY_USER, headless=True,
+                 password=const.INF_VCENTER_READONLY_PASSWORD):
+        options = Options()
+        options.headless = headless
+        self._driver = webdriver.Firefox(options=options, service_log_path='/var/log/webdriver.log')
+        self._driver.get(url)
+        self._username = username
+        self._password = password
+        self._login()
+        self._console = self._get_console()
+        self.keys = Keys
+
+    def _login(self):
+        # Waits upwards of 30 seconds for the page to load
+        username_field = WebDriverWait(self._driver, 30).until(
+            EC.presence_of_element_located((By.ID, "username")))
+        username_field.send_keys('readonly@vsphere.local')
+        password_field = self._driver.find_element_by_id('password')
+        password_field.send_keys('a')
+        login_button = self._driver.find_element_by_id('submit')
+        login_button.click()
+
+    def _get_console(self):
+        # Waits upwards of 30 seconds for the page to load
+        console = WebDriverWait(self._driver, 30).until(
+            EC.presence_of_element_located((By.ID, "mainCanvas")))
+        return console
+
+    def __enter__(self):
+        """Enables use of the ``with`` statement"""
+        return self
+
+    def __exit__(self, exc_type, exc_value, the_traceback):
+        self._driver.quit()
+
+    def send_keys(self, *args, auto_enter=True):
+        """Like, if you were to type with your keyboard.
+
+        For non-standard keys (like ENTER, SHIFT, etc), look at the
+        vSphereConsole.keys object.
+
+        :Returns: None
+
+        :param *args: The series of keys you want to input to the console
+        :type *args: List
+
+        :param auto_enter: Presses the ENTER key for you when set to True.
+        :type auto_enter: Boolean
+        """
+        self._console.send_keys(*args)
+        time.sleep(0.5) # Give the HTML console time to react to input
+        if auto_enter:
+            self._console.send_keys(Keys.ENTER)
+            time.sleep(0.5)
+
+
+def join_existing_cluster(console_url, cluster_name, logger):
+    """Adds a new node to an existing cluster"""
+    logger.info('Setting up Selenium')
+    with vSphereConsole(console_url) as console:
+        logger.info('Waiting {} seconds for node to fully boot'.format(BOOT_WAIT))
+        time.sleep(BOOT_WAIT) # Wait for the node to finish booting
+        logger.info('Formatting disks')
+        format_disks(console)
+        logger.info('Joining cluster {}'.format(cluster_name))
+        console.send_keys('2')
+        console.send_keys(cluster_name)
+        logger.info('Waiting {} seconds for the node to join'.format(BUILD_WAIT))
+        time.sleep(BUILD_WAIT)
+
+
+def configure_new_cluster(version, logger, **kwargs):
+    """Because for some reason, the order of the Wizard changes with OneFS releases...
+
+    :param version: The version of OneFS to configure
+    :type version: String
+    """
+    if version >= '8.1.2.0':
+        logger.info('Config OneFS >= 8.1.2.0')
+        return configure_new_8_1_2_cluster(logger=logger, **kwargs)
+    elif version >= '8.1.0.0':
+        logger.info('Config OneFS 8.1.0 -> 8.1.1')
+        return configure_new_8_1_cluster(logger=logger, **kwargs)
+    else:
+        logger.info('Config OneFS 8.0.0')
+        return configure_new_8_0_cluster(logger=logger, **kwargs)
+
+
+def configure_new_8_0_cluster(console_url, cluster_name, int_netmask, int_ip_low, int_ip_high,
+                              ext_netmask, ext_ip_low, ext_ip_high, gateway, dns_servers,
+                              encoding, sc_zonename, smartconnect_ip, logger):
+    """Walk through the config Wizard to create a functional one-node cluster
+
+    :Returns: None
+
+    :param console_url: The URL to the vSphere HTML console for the OneFS node
+    :type console_url: String
+
+    :param cluster_name: The name to give the new cluster
+    :type cluster_name: String
+
+    :param int_netmask: The subnet mask for the internal OneFS network
+    :type int_netmask: String
+
+    :param int_ip_low: The smallest IP to assign to an internal NIC
+    :type int_ip_low: String (IPv4 address)
+
+    :param int_ip_high: The largest IP to assign to an internal NIC
+    :type int_ip_high: String (IPv4 address)
+
+    :param ext_ip_low: The smallest IP to assign to an external/public NIC
+    :type ext_ip_low: String (IPv4 address)
+
+    :param ext_ip_high: The largest IP to assign to an external/public NIC
+    :type ext_ip_high: String (IPv4 address)
+
+    :param gateway: The IP address for the default gateway
+    :type gateway: String (IPv4 address)
+
+    :param dns_servers: A common separated list of IPs of the DNS servers to use
+    :type dns_servers: String
+
+    :param encoding: The filesystem encoding to use.
+    :type encoding: String
+
+    :param sc_zonename: The SmartConnect Zone name to use. Skipped if None.
+    :type sc_zonename: String
+
+    :param smartconnect_ip: The IPv4 address to use as the SIP
+    :type smartconnect_ip: String (IPv4 address)
+
+    :param logger: A object for logging information/errors
+    :type logger: logging.Logger
+    """
+    logger.info('Setting up Selenium')
+    with vSphereConsole(console_url) as console:
+        logger.info('Waiting {} seconds for node to fully boot'.format(BOOT_WAIT))
+        time.sleep(BOOT_WAIT) # Wait for the node to finish booting
+        logger.info('Formatting disks')
+        format_disks(console)
+        logger.info('Accepting EULA')
+        make_new_and_accept_eual(console)
+        logger.info('Setting root and admin passwords')
+        set_passwords(console)
+        logger.info('Skipping ESRS config')
+        set_esrs(console) # 8.0.0.x; ESRS comes before everything else...
+        logger.info("Naming cluster {}".format(cluster_name))
+        set_name(console, cluster_name)
+        logger.info("Settings encoding to {}".format(encoding))
+        set_encoding(console, encoding)
+        # setup int network
+        logger.info('Setting up internal network - Mask: {} Low: {} High: {}'.format(int_netmask, int_ip_low, int_ip_high))
+        config_network(console, netmask=int_netmask, ip_low=int_ip_low, ip_high=int_ip_high)
+        # setup ext network
+        logger.info('Settings up external network - Mask: {} Low: {} High: {}'.format(ext_netmask, ext_ip_low, ext_ip_high))
+        config_network(console, netmask=ext_netmask, ip_low=ext_ip_low, ip_high=ext_ip_high)
+        logger.info('Setting up default gateway for ext network to {}'.format(gateway))
+        set_default_gateway(console, gateway)
+        logger.info('Configuring SmartConnect - Zone: {} IP: {}'.format(sc_zonename, smartconnect_ip))
+        set_smartconnect(console, sc_zonename, smartconnect_ip)
+        logger.info('Setting DNS servers to {}'.format(dns_servers))
+        set_dns(console, dns_servers)
+        logger.info('Skipping timezone config')
+        set_timezone(console)
+        logger.info('Skipping join mode config')
+        set_join_mode(console)
+        logger.info('Commiting changes and waiting {} seconds'.format(BUILD_WAIT))
+        commit_config(console)
+        time.sleep(BUILD_WAIT)
+
+
+def configure_new_8_1_cluster(console_url, cluster_name, int_netmask, int_ip_low, int_ip_high,
+                              ext_netmask, ext_ip_low, ext_ip_high, gateway, dns_servers,
+                              encoding, sc_zonename, smartconnect_ip, logger):
+    """Walk through the config Wizard to create a functional one-node cluster
+
+    :Returns: None
+
+    :param console_url: The URL to the vSphere HTML console for the OneFS node
+    :type console_url: String
+
+    :param cluster_name: The name to give the new cluster
+    :type cluster_name: String
+
+    :param int_netmask: The subnet mask for the internal OneFS network
+    :type int_netmask: String
+
+    :param int_ip_low: The smallest IP to assign to an internal NIC
+    :type int_ip_low: String (IPv4 address)
+
+    :param int_ip_high: The largest IP to assign to an internal NIC
+    :type int_ip_high: String (IPv4 address)
+
+    :param ext_ip_low: The smallest IP to assign to an external/public NIC
+    :type ext_ip_low: String (IPv4 address)
+
+    :param ext_ip_high: The largest IP to assign to an external/public NIC
+    :type ext_ip_high: String (IPv4 address)
+
+    :param gateway: The IP address for the default gateway
+    :type gateway: String (IPv4 address)
+
+    :param dns_servers: A common separated list of IPs of the DNS servers to use
+    :type dns_servers: String
+
+    :param encoding: The filesystem encoding to use.
+    :type encoding: String
+
+    :param sc_zonename: The SmartConnect Zone name to use. Skipped if None.
+    :type sc_zonename: String
+
+    :param smartconnect_ip: The IPv4 address to use as the SIP
+    :type smartconnect_ip: String (IPv4 address)
+
+    :param logger: A object for logging information/errors
+    :type logger: logging.Logger
+    """
+    logger.info('Setting up Selenium')
+    with vSphereConsole(console_url) as console:
+        logger.info('Waiting {} seconds for node to fully boot'.format(BOOT_WAIT))
+        time.sleep(BOOT_WAIT)
+        logger.info('Formatting disks')
+        format_disks(console)
+        logger.info('Accepting EULA')
+        make_new_and_accept_eual(console)
+        logger.info('Setting root and admin passwords')
+        set_passwords(console)
+        logger.info("Naming cluster {}".format(cluster_name))
+        set_name(console, cluster_name) # 8.1.0.4 name comes before ESRS
+        logger.info("Settings encoding to {}".format(encoding))
+        set_encoding(console, encoding)
+        logger.info('Skipping ESRS config')
+        set_esrs(console)
+        # setup int network
+        logger.info('Setting up internal network - Mask: {} Low: {} High: {}'.format(int_netmask, int_ip_low, int_ip_high))
+        config_network(console, netmask=int_netmask, ip_low=int_ip_low, ip_high=int_ip_high)
+        # setup ext network
+        logger.info('Settings up external network - Mask: {} Low: {} High: {}'.format(ext_netmask, ext_ip_low, ext_ip_high))
+        config_network(console, netmask=ext_netmask, ip_low=ext_ip_low, ip_high=ext_ip_high)
+        logger.info('Setting up default gateway for ext network to {}'.format(gateway))
+        set_default_gateway(console, gateway)
+        logger.info('Configuring SmartConnect - Zone: {} IP: {}'.format(sc_zonename, smartconnect_ip))
+        set_smartconnect(console, sc_zonename, smartconnect_ip)
+        logger.info('Setting DNS servers to {}'.format(dns_servers))
+        set_dns(console, dns_servers)
+        logger.info('Skipping timezone config')
+        set_timezone(console)
+        logger.info('Skipping join mode config')
+        set_join_mode(console)
+        logger.info('Commiting changes and waiting {} seconds'.format(BUILD_WAIT))
+        commit_config(console)
+        time.sleep(BUILD_WAIT)
+
+
+def configure_new_8_1_2_cluster(console_url, cluster_name, int_netmask, int_ip_low, int_ip_high,
+                              ext_netmask, ext_ip_low, ext_ip_high, gateway, dns_servers,
+                              encoding, sc_zonename, smartconnect_ip, logger):
+    """Walk through the config Wizard to create a functional one-node cluster
+
+    :Returns: None
+
+    :param console_url: The URL to the vSphere HTML console for the OneFS node
+    :type console_url: String
+
+    :param cluster_name: The name to give the new cluster
+    :type cluster_name: String
+
+    :param int_netmask: The subnet mask for the internal OneFS network
+    :type int_netmask: String
+
+    :param int_ip_low: The smallest IP to assign to an internal NIC
+    :type int_ip_low: String (IPv4 address)
+
+    :param int_ip_high: The largest IP to assign to an internal NIC
+    :type int_ip_high: String (IPv4 address)
+
+    :param ext_ip_low: The smallest IP to assign to an external/public NIC
+    :type ext_ip_low: String (IPv4 address)
+
+    :param ext_ip_high: The largest IP to assign to an external/public NIC
+    :type ext_ip_high: String (IPv4 address)
+
+    :param gateway: The IP address for the default gateway
+    :type gateway: String (IPv4 address)
+
+    :param dns_servers: A common separated list of IPs of the DNS servers to use
+    :type dns_servers: String
+
+    :param encoding: The filesystem encoding to use.
+    :type encoding: String
+
+    :param sc_zonename: The SmartConnect Zone name to use. Skipped if None.
+    :type sc_zonename: String
+
+    :param smartconnect_ip: The IPv4 address to use as the SIP
+    :type smartconnect_ip: String (IPv4 address)
+
+    :param logger: A object for logging information/errors
+    :type logger: logging.Logger
+    """
+    logger.info('Setting up Selenium')
+    with vSphereConsole(console_url) as console:
+        logger.info('Waiting {} seconds for node to fully boot'.format(BOOT_WAIT))
+        time.sleep(BOOT_WAIT)
+        logger.info('Formatting disks')
+        format_disks(console)
+        logger.info('Accepting EULA')
+        make_new_and_accept_eual(console)
+        logger.info('Setting root and admin passwords')
+        set_passwords(console)
+        logger.info("Naming cluster {}".format(cluster_name))
+        set_name(console, cluster_name) # 8.1.0.4 name comes before ESRS
+        logger.info("Settings encoding to {}".format(encoding))
+        set_encoding(console, encoding)
+        logger.info('Skipping ESRS config')
+        # ESRS not even set via Wizard...
+        # setup int network
+        logger.info('Setting up internal network - Mask: {} Low: {} High: {}'.format(int_netmask, int_ip_low, int_ip_high))
+        config_network(console, netmask=int_netmask, ip_low=int_ip_low, ip_high=int_ip_high)
+        # setup ext network
+        logger.info('Settings up external network - Mask: {} Low: {} High: {}'.format(ext_netmask, ext_ip_low, ext_ip_high))
+        config_network(console, netmask=ext_netmask, ip_low=ext_ip_low, ip_high=ext_ip_high)
+        logger.info('Setting up default gateway for ext network to {}'.format(gateway))
+        set_default_gateway(console, gateway)
+        logger.info('Configuring SmartConnect - Zone: {} IP: {}'.format(sc_zonename, smartconnect_ip))
+        set_smartconnect(console, sc_zonename, smartconnect_ip)
+        logger.info('Setting DNS servers to {}'.format(dns_servers))
+        set_dns(console, dns_servers)
+        logger.info('Skipping timezone config')
+        set_timezone(console)
+        logger.info('Skipping join mode config')
+        set_join_mode(console)
+        logger.info('Commiting changes and waiting {} seconds'.format(BUILD_WAIT))
+        commit_config(console)
+        time.sleep(BUILD_WAIT)
+
+
+def format_disks(console):
+    """vOneFS clusters require you to format the new VMDKs"""
+    console.send_keys('yes')
+    # sleep here while disks format...
+    time.sleep(FORMAT_WAIT)
+
+
+def make_new_and_accept_eual(console):
+    """First prompt of the Wizard; choose to make a new cluster, and accept the EULA"""
+    # 1 means "make a new cluster"
+    console.send_keys('1')
+    # Accept EULA
+    # Skip to the yes/no prompt
+    console.send_keys(console.keys.SHIFT, 'g', auto_enter=False)
+    console.send_keys('yes')
+
+
+def set_passwords(console, root='a', admin='a'):
+    """Set the root and admin user passwords"""
+    # Set root password
+    console.send_keys(root)
+    # Confirm root password
+    console.send_keys(root)
+    # Set admin password
+    console.send_keys(admin)
+    # Confirm admin password
+    console.send_keys(admin)
+
+
+def set_esrs(console, enabled='no'):
+    """Configure ESRS"""
+    console.send_keys(enabled)
+
+
+def set_name(console, cluster_name):
+    """Define the name of the new cluster"""
+    # set cluster name
+    console.send_keys(cluster_name)
+
+
+def set_encoding(console, encoding):
+    """Choose the filesystem encoding used"""
+    # config for UTF8 encoding
+    mapping = {
+        'windows-sjis' : '1',
+        'windows-949' : '2',
+        'windows-1252' : '3',
+        'euc-kr' : '4',
+        'euc-jp' : '5',
+        'euc-jp-ms' : '6',
+        'utf-8-mac' : '7',
+        'utf-8' : '8',
+        'latin-1' : '9',
+        'latin-2' : '10',
+        'latin-3' : '11',
+        'latin-4' : '12',
+        'cyrillic' : '13',
+        'arabic' : '14',
+        'greek' : '15',
+        'hebrew' : '16',
+        'latin-5' : '17',
+        'latin-6' : '18',
+        'latin-7' : '19',
+        'latin-8' : '20',
+        'latin-9' : '21',
+        'latin-10' : '22'
+    }
+    console.send_keys(mapping[encoding.lower()])
+
+
+def config_network(console, netmask, ip_low, ip_high):
+    """Setting external or internal network information is the same series of prmopts"""
+    # set Netmask
+    console.send_keys('1')
+    console.send_keys(netmask)
+    # config IP range
+    console.send_keys('3')
+    # Add IP range
+    console.send_keys('1')
+    console.send_keys(ip_low)
+    # Clear out the low IP
+    for char in ip_low:
+        console.send_keys(console.keys.BACKSPACE, auto_enter=False)
+    console.send_keys(ip_high, auto_enter=False)
+    # Keep current config
+    console.send_keys(console.keys.ENTER, auto_enter=False)
+    # onto the next section
+    console.send_keys(Keys.ENTER, auto_enter=False)
+    console.send_keys(Keys.ENTER, auto_enter=False)
+    console.send_keys(Keys.ENTER, auto_enter=False)
+
+
+def set_default_gateway(console, gateway):
+    """Define the default gateway for the external network"""
+    # set default gateway
+    console.send_keys(gateway)
+
+
+def set_smartconnect(console, sc_zonename=None, smartconnect_ip=None):
+    """Configure SmartConnect"""
+    if sc_zonename:
+        console.send_keys('1')
+        console.send_keys(sc_zonename)
+    if smartconnect_ip:
+        console.send_keys('2')
+        console.send_keys(smartconnect_ip)
+    console.send_keys(console.keys.ENTER, auto_enter=False)
+
+
+def set_dns(console, dns_servers):
+    """Configure the DNS servers the external network uses
+
+    dsn_servers must be an IPv4 address or common delimited IPv4 addresses
+    """
+    # Set DNS server(s)
+    console.send_keys('1')
+    console.send_keys(dns_servers)
+    # Exit DNS config
+    console.send_keys(console.keys.ENTER, auto_enter=False)
+    # Exit Ext network config
+    console.send_keys(console.keys.ENTER, auto_enter=False)
+
+
+def set_timezone(console, timezone=None):
+    """Configure the timezone information"""
+    # Skip timezone stuff
+    console.send_keys(Keys.ENTER, auto_enter=False)
+
+
+def set_join_mode(console):
+    """Define the mode nodes need to join the cluster"""
+    # Keep default join mode
+    console.send_keys(Keys.ENTER, auto_enter=False)
+
+
+def commit_config(console):
+    """Submit the new config"""
+    # Commit changes?
+    console.send_keys('yes')

--- a/vlab_onefs_api/lib/worker/vmware.py
+++ b/vlab_onefs_api/lib/worker/vmware.py
@@ -27,7 +27,6 @@ def show_onefs(username):
         folder = vcenter.get_by_name(name=username, vimtype=vim.Folder)
         onefs_vms = {}
         for vm in folder.childEntity:
-            logger.info(vm.name)
             info = virtual_machine.get_info(vcenter, vm)
             kind, version = info['note'].split('=')
             if kind == 'OneFS':


### PR DESCRIPTION
## Summary
A significant request from users is the ability to _"push a button, and get a usable OneFS cluster"_. After automating the OneFS configuration wizard, I understand why they don't want to manually do this.

With this PR, the OneFS service will expose an API end point that can be used to setup a new cluster, or join a new node to an existing cluster.

**Note:** The diff stats on this PR makes it look much bigger than it really is. A lot of the additional line count is docstring and breaking out input parameters across multiple lines. OneFS has a lot of config options, which need to be passed from the API -> Task -> Lib (that does the actual work).

## Implementation 
The OneFS configuration wizard is exposed via the terminal when a new node is powered on. This means there are strictly two options for automating the wizard:
1) Use something like Selenium with the VMware HTML console
-or-
2) Set up a vSPC server, and use something like [pexpect](https://pypi.org/project/pexpect/)

The biggest downside to option 1 (Selenium) is that the HTML console is implemented via an HTML5 [canvas](https://www.w3schools.com/html/html5_canvas.asp). This means that we can [send_keys](https://selenium-python.readthedocs.io/api.html#selenium.webdriver.common.action_chains.ActionChains.send_keys) to the page element, but there's no way to parse the prompt to understand _where in the wizard_ the automation is at.

The downsides to option 2 (vSPC + pexpect) is that we have to setup a vSPC server, which it wont dynamically scale as we add more worker services, and we'd have to modify the OneFS OVA (either statically, or dynamically upon deploy) to use a serial console. A potential downside of using the serial console would be losing the HTML console entirely.

After talking with some colleagues that have used  [vspc.py](https://pypi.org/project/vmware-vspc/) and/or using pexpect with the OneFS config wizard, and my own personal experience with browser automation via Selenium, it really seems like choosing between option 1 and 2 is like choosing _which terrible problem domain do you want to deal with_. 

With this in mind, I choose to go with the devil I know: Selenium.