### PR TITLE
Bug double config, fixes #5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,9 +21,9 @@ services:
       - ./vlab_onefs_api:/usr/local/lib/python3.6/dist-packages/vlab_onefs_api/
       - /mnt/raid/images/onefs:/images:ro
     environment:
-      - INF_VCENTER_SERVER=virtlab.igs.corp
-      - INF_VCENTER_USER=Administrator@vsphere.local
-      - INF_VCENTER_PASSWORD=1.Password
+      - INF_VCENTER_SERVER=changeME
+      - INF_VCENTER_USER=changeME
+      - INF_VCENTER_PASSWORD=changeME
       - INF_VCENTER_TOP_LVL_DIR=/vlab
 
   onefs-broker:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-onefs-api",
       author="Nicholas Willhite,",
       author_email='willnx84@gmail.com',
-      version='2018.11.14',
+      version='2018.12.06',
       packages=find_packages(),
       include_package_data=True,
       package_files={'vlab_onefs_api' : ['app.ini']},

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -92,7 +92,8 @@ class TestTasks(unittest.TestCase):
     @patch.object(tasks, 'setup_onefs')
     def test_config(self, fake_setup_onefs, fake_vmware):
         """``config`` returns a dictionary upon success"""
-        fake_vmware.show_onefs.return_value = {'mycluster-1' : {'console': 'https://htmlconsole.com'}}
+        fake_vmware.show_onefs.return_value = {'mycluster-1' : {'console': 'https://htmlconsole.com',
+                                                                'info': {'configured': False}}}
 
         output = tasks.config(cluster_name='mycluster',
                               name='mycluster-1',
@@ -118,7 +119,8 @@ class TestTasks(unittest.TestCase):
     @patch.object(tasks, 'setup_onefs')
     def test_config_join(self, fake_setup_onefs, fake_vmware):
         """``config`` returns a dictionary upon joining a node to an existing cluster"""
-        fake_vmware.show_onefs.return_value = {'mycluster-1' : {'console': 'https://htmlconsole.com'}}
+        fake_vmware.show_onefs.return_value = {'mycluster-1' : {'console': 'https://htmlconsole.com',
+                                                                'info': {'configured': False}}}
 
         output = tasks.config(cluster_name='mycluster',
                               name='mycluster-1',
@@ -166,11 +168,33 @@ class TestTasks(unittest.TestCase):
 
         self.assertEqual(output, expected)
 
+    @patch.object(tasks, 'vmware')
+    @patch.object(tasks, 'setup_onefs')
+    def test_config_already_configed(self, fake_setup_onefs, fake_vmware):
+        """``config`` returns an error if the node is already configured"""
+        fake_vmware.show_onefs.return_value = {'mycluster-1' : {'console': 'https://htmlconsole.com',
+                                                                'info': {'configured': True}}}
 
 
+        output = tasks.config(cluster_name='mycluster',
+                              name='mycluster-1',
+                              username='bob',
+                              version='8.1.1.0',
+                              int_netmask='255.255.255.0',
+                              int_ip_low='5.5.5.1',
+                              int_ip_high='5.5.5.10',
+                              ext_netmask='255.255.255.0',
+                              ext_ip_low='10.1.1.2',
+                              ext_ip_high='10.1.1.20',
+                              gateway='10.1.1.1',
+                              dns_servers='1.1.1.1,8.8.8.8',
+                              encoding='utf-8',
+                              sc_zonename='myzone.foo.com',
+                              smartconnect_ip='10.1.1.21',
+                              join_cluster=False)
+        expected = {'content': {}, 'error': "Cannot configure a node that's already configured", 'params': {}}
 
-
-
+        self.assertEqual(output, expected)
 
 
 if __name__ == '__main__':

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -15,7 +15,7 @@ class TestTasks(unittest.TestCase):
         """``show`` returns a dictionary when everything works as expected"""
         fake_vmware.show_onefs.return_value = {'worked': True}
 
-        output = tasks.show(username='bob')
+        output = tasks.show(username='bob', txn_id='myId')
         expected = {'content' : {'worked': True}, 'error': None, 'params': {}}
 
         self.assertEqual(output, expected)
@@ -25,7 +25,7 @@ class TestTasks(unittest.TestCase):
         """``show`` sets the error in the dictionary to the ValueError message"""
         fake_vmware.show_onefs.side_effect = [ValueError("testing")]
 
-        output = tasks.show(username='bob')
+        output = tasks.show(username='bob', txn_id='myId')
         expected = {'content' : {}, 'error': 'testing', 'params': {}}
 
         self.assertEqual(output, expected)
@@ -39,7 +39,8 @@ class TestTasks(unittest.TestCase):
                               machine_name='isi01',
                               image='8.0.04',
                               front_end='externalNetwork',
-                              back_end='internalNetwork')
+                              back_end='internalNetwork',
+                              txn_id='myId')
         expected = {'content' : {'worked': True}, 'error': None, 'params': {}}
 
         self.assertEqual(output, expected)
@@ -53,7 +54,8 @@ class TestTasks(unittest.TestCase):
                               machine_name='isi01',
                               image='8.0.04',
                               front_end='externalNetwork',
-                              back_end='internalNetwork')
+                              back_end='internalNetwork',
+                              txn_id='myId')
         expected = {'content' : {}, 'error': 'testing', 'params': {}}
 
         self.assertEqual(output, expected)
@@ -63,7 +65,7 @@ class TestTasks(unittest.TestCase):
         """``delete`` returns a dictionary when everything works as expected"""
         fake_vmware.delete_onefs.return_value = {'worked': True}
 
-        output = tasks.delete(username='bob', machine_name='isi01')
+        output = tasks.delete(username='bob', machine_name='isi01', txn_id='myId')
         expected = {'content' : {}, 'error': None, 'params': {}}
 
         self.assertEqual(output, expected)
@@ -73,7 +75,7 @@ class TestTasks(unittest.TestCase):
         """``delete`` sets the error in the dictionary to the ValueError message"""
         fake_vmware.delete_onefs.side_effect = [ValueError("testing")]
 
-        output = tasks.delete(username='bob', machine_name='isi01')
+        output = tasks.delete(username='bob', machine_name='isi01', txn_id='myId')
         expected = {'content' : {}, 'error': 'testing', 'params': {}}
 
         self.assertEqual(output, expected)
@@ -83,7 +85,7 @@ class TestTasks(unittest.TestCase):
         """``image`` returns a dictionary when everything works as expected"""
         fake_vmware.list_images.return_value = []
 
-        output = tasks.image()
+        output = tasks.image(txn_id='myId')
         expected = {'content' : {'image': []}, 'error': None, 'params': {}}
 
         self.assertEqual(output, expected)
@@ -110,7 +112,8 @@ class TestTasks(unittest.TestCase):
                               encoding='utf-8',
                               sc_zonename='myzone.foo.com',
                               smartconnect_ip='10.1.1.21',
-                              join_cluster=False)
+                              join_cluster=False,
+                              txn_id='myId')
         expected = {'content': {}, 'error': None, 'params': {}}
 
         self.assertEqual(output, expected)
@@ -137,7 +140,8 @@ class TestTasks(unittest.TestCase):
                               encoding='utf-8',
                               sc_zonename='myzone.foo.com',
                               smartconnect_ip='10.1.1.21',
-                              join_cluster=True)
+                              join_cluster=True,
+                              txn_id='myId')
         expected = {'content': {}, 'error': None, 'params': {}}
 
         self.assertEqual(output, expected)
@@ -163,7 +167,8 @@ class TestTasks(unittest.TestCase):
                               encoding='utf-8',
                               sc_zonename='myzone.foo.com',
                               smartconnect_ip='10.1.1.21',
-                              join_cluster=False)
+                              join_cluster=False,
+                              txn_id='myId')
         expected = {'content': {}, 'error': 'No node named mycluster-1 found', 'params': {}}
 
         self.assertEqual(output, expected)
@@ -191,7 +196,8 @@ class TestTasks(unittest.TestCase):
                               encoding='utf-8',
                               sc_zonename='myzone.foo.com',
                               smartconnect_ip='10.1.1.21',
-                              join_cluster=False)
+                              join_cluster=False,
+                              txn_id='myId')
         expected = {'content': {}, 'error': "Cannot configure a node that's already configured", 'params': {}}
 
         self.assertEqual(output, expected)

--- a/vlab_onefs_api/lib/views/onefs.py
+++ b/vlab_onefs_api/lib/views/onefs.py
@@ -147,7 +147,7 @@ class OneFSView(TaskView):
                          "not": {"required": ["ext_ip_high", "ext_ip_low", "ext_netmask",
                                               "int_ip_high", "int_ip_low", "int_netmask",
                                               "dns_servers", "sc_zonename", "smartconnect_ip",
-                                              "encoding", "version"
+                                              "encoding", "version", "gateway"
                                               ]
                                 }
                         },
@@ -155,6 +155,7 @@ class OneFSView(TaskView):
                                       "ext_ip_high","ext_ip_low", "ext_netmask",
                                       "int_ip_high", "int_ip_low", "int_netmask",
                                       "dns_servers", "sc_zonename", "smartconnect_ip",
+                                      "gateway"
                                       ],
                          "not": {"required": ["join"]}
                         }

--- a/vlab_onefs_api/lib/views/onefs.py
+++ b/vlab_onefs_api/lib/views/onefs.py
@@ -22,7 +22,7 @@ logger = get_logger(__name__, loglevel=const.VLAB_ONEFS_LOG_LEVEL)
 
 
 class OneFSView(TaskView):
-    """API end point TODO"""
+    """API end point for working with OneFS nodes"""
     route_base = '/api/1/inf/onefs'
     POST_SCHEMA = { "$schema": "http://json-schema.org/draft-04/schema#",
                     "type": "object",
@@ -162,7 +162,7 @@ class OneFSView(TaskView):
                      ]
                     }
 
-    @requires(verify=const.VLAB_VERIFY_TOKEN, version=(1,2))
+    @requires(verify=const.VLAB_VERIFY_TOKEN, version=2)
     @describe(post=POST_SCHEMA, delete=DELETE_SCHEMA, get_args=GET_SCHEMA)
     def get(self, *args, **kwargs):
         """Display the vOneFS nodes you own"""
@@ -175,7 +175,7 @@ class OneFSView(TaskView):
         resp.headers.add('Link', '<{0}{1}/task/{2}>; rel=status'.format(const.VLAB_URL, self.route_base, task.id))
         return resp
 
-    @requires(verify=const.VLAB_VERIFY_TOKEN, version=(1,2)) # XXX remove verify=False before commit
+    @requires(verify=const.VLAB_VERIFY_TOKEN, version=2)
     @validate_input(schema=POST_SCHEMA)
     def post(self, *args, **kwargs):
         """Create a new vOneFS node"""
@@ -194,7 +194,7 @@ class OneFSView(TaskView):
         resp.headers.add('Link', '<{0}{1}/config>; rel=config>'.format(const.VLAB_URL, self.route_base))
         return resp
 
-    @requires(verify=const.VLAB_VERIFY_TOKEN, version=(1,2)) # XXX remove verify=False before commit
+    @requires(verify=const.VLAB_VERIFY_TOKEN, version=2)
     @validate_input(schema=DELETE_SCHEMA)
     def delete(self, *args, **kwargs):
         """Destroy a vOneFS node"""
@@ -209,7 +209,7 @@ class OneFSView(TaskView):
         return resp
 
     @route('/image', methods=["GET"])
-    @requires(verify=const.VLAB_VERIFY_TOKEN, version=(1,2))
+    @requires(verify=const.VLAB_VERIFY_TOKEN, version=2)
     @describe(get=IMAGES_SCHEMA)
     def image(self, *args, **kwargs):
         """Show available versions of OneFS that can be deployed"""

--- a/vlab_onefs_api/lib/views/onefs.py
+++ b/vlab_onefs_api/lib/views/onefs.py
@@ -167,8 +167,9 @@ class OneFSView(TaskView):
     def get(self, *args, **kwargs):
         """Display the vOneFS nodes you own"""
         username = kwargs['token']['username']
+        txn_id = request.headers.get('X-REQUEST-ID', 'noId')
         resp_data = {'user' : username}
-        task = current_app.celery_app.send_task('onefs.show', [username])
+        task = current_app.celery_app.send_task('onefs.show', [username, txn_id])
         resp_data['content'] = {'task-id': task.id}
         resp = Response(ujson.dumps(resp_data))
         resp.status_code = 202
@@ -180,13 +181,14 @@ class OneFSView(TaskView):
     def post(self, *args, **kwargs):
         """Create a new vOneFS node"""
         username = kwargs['token']['username']
+        txn_id = request.headers.get('X-REQUEST-ID', 'noId')
         resp_data = {'user' : username}
         body = kwargs['body']
         machine_name = body['name']
         image = body['image']
         front_end = body['frontend']
         back_end = body['backend']
-        task = current_app.celery_app.send_task('onefs.create', [username, machine_name, image, front_end, back_end])
+        task = current_app.celery_app.send_task('onefs.create', [username, machine_name, image, front_end, back_end, txn_id])
         resp_data['content'] = {'task-id': task.id}
         resp = Response(ujson.dumps(resp_data))
         resp.status_code = 202
@@ -199,9 +201,10 @@ class OneFSView(TaskView):
     def delete(self, *args, **kwargs):
         """Destroy a vOneFS node"""
         username = kwargs['token']['username']
+        txn_id = request.headers.get('X-REQUEST-ID', 'noId')
         resp_data = {'user' : username}
         machine_name = kwargs['body']['name']
-        task = current_app.celery_app.send_task('onefs.delete', [username, machine_name])
+        task = current_app.celery_app.send_task('onefs.delete', [username, machine_name, txn_id])
         resp_data['content'] = {'task-id': task.id}
         resp = Response(ujson.dumps(resp_data))
         resp.status_code = 202
@@ -214,8 +217,9 @@ class OneFSView(TaskView):
     def image(self, *args, **kwargs):
         """Show available versions of OneFS that can be deployed"""
         username = kwargs['token']['username']
+        txn_id = request.headers.get('X-REQUEST-ID', 'noId')
         resp_data = {'user' : username}
-        task = current_app.celery_app.send_task('onefs.image')
+        task = current_app.celery_app.send_task('onefs.image', [txn_id])
         resp_data['content'] = {'task-id': task.id}
         resp = Response(ujson.dumps(resp_data))
         resp.status_code = 202
@@ -230,6 +234,7 @@ class OneFSView(TaskView):
         """Set the configuration of a OneFS node"""
         status_code = 202
         username = kwargs['token']['username']
+        txn_id = request.headers.get('X-REQUEST-ID', 'noId')
         resp_data = {'user' : username}
         # Aligning these just makes it easier to read
         cluster_name    = kwargs['body']['cluster_name']
@@ -280,7 +285,8 @@ class OneFSView(TaskView):
                                                                             'encoding' : encoding,
                                                                             'sc_zonename' : sc_zonename,
                                                                             'smartconnect_ip' : smartconnect_ip,
-                                                                            'join_cluster' : join_cluster})
+                                                                            'join_cluster' : join_cluster,
+                                                                            'txn_id' : txn_id})
 
             resp_data['content'] = {'task-id': task.id}
             link = '<{0}{1}/task/{2}>; rel=status'.format(const.VLAB_URL, self.route_base, task.id)

--- a/vlab_onefs_api/lib/worker/setup_onefs.py
+++ b/vlab_onefs_api/lib/worker/setup_onefs.py
@@ -69,10 +69,10 @@ class vSphereConsole(object):
         :type auto_enter: Boolean
         """
         self._console.send_keys(*args)
-        time.sleep(0.5) # Give the HTML console time to react to input
+        time.sleep(1) # Give the HTML console time to react to input
         if auto_enter:
             self._console.send_keys(Keys.ENTER)
-            time.sleep(0.5)
+            time.sleep(1)
 
 
 def join_existing_cluster(console_url, cluster_name, logger):

--- a/vlab_onefs_api/lib/worker/tasks.py
+++ b/vlab_onefs_api/lib/worker/tasks.py
@@ -3,25 +3,27 @@
 Entry point logic for available backend worker tasks
 """
 from celery import Celery
-from celery.utils.log import get_task_logger
+from vlab_api_common import get_task_logger
 
 from vlab_onefs_api.lib import const
 from vlab_onefs_api.lib.worker import vmware, setup_onefs
 
 app = Celery('onefs', backend='rpc://', broker=const.VLAB_MESSAGE_BROKER)
-logger = get_task_logger(__name__)
-logger.setLevel(const.VLAB_ONEFS_LOG_LEVEL.upper())
 
 
-@app.task(name='onefs.show')
-def show(username):
+@app.task(name='onefs.show', bind=True)
+def show(self, username, txn_id):
     """Obtain basic information about onefs
 
     :Returns: Dictionary
 
     :param username: The name of the user who wants info about their default gateway
     :type username: String
+
+    :param txn_id: A unique string supplied by the client to track the call through logs
+    :type txn_id: String
     """
+    logger = get_task_logger(txn_id=txn_id, task_id=self.request.id, loglevel=const.VLAB_ONEFS_LOG_LEVEL.upper())
     resp = {'content' : {}, 'error': None, 'params': {}}
     logger.info('Task starting')
     try:
@@ -35,9 +37,9 @@ def show(username):
     return resp
 
 
-@app.task(name='onefs.create')
-def create(username, machine_name, image, front_end, back_end):
-    """TODO
+@app.task(name='onefs.create', bind=True)
+def create(self, username, machine_name, image, front_end, back_end, txn_id):
+    """Deploy a new OneFS node
 
     :Returns: Dictionary
 
@@ -55,7 +57,11 @@ def create(username, machine_name, image, front_end, back_end):
 
     :param back_end: The network to hook the internal network to
     :type back_end: String
+
+    :param txn_id: A unique string supplied by the client to track the call through logs
+    :type txn_id: String
     """
+    logger = get_task_logger(txn_id=txn_id, task_id=self.request.id, loglevel=const.VLAB_ONEFS_LOG_LEVEL.upper())
     resp = {'content' : {}, 'error': None, 'params': {}}
     logger.info('Task starting')
     try:
@@ -67,9 +73,9 @@ def create(username, machine_name, image, front_end, back_end):
     return resp
 
 
-@app.task(name='onefs.delete')
-def delete(username, machine_name):
-    """TODO
+@app.task(name='onefs.delete', bind=True)
+def delete(self, username, machine_name, txn_id):
+    """Destroy a OneFS node
 
     :Returns: Dictionary
 
@@ -78,7 +84,11 @@ def delete(username, machine_name):
 
     :param machine_name: The name of the instance of onefs
     :type machine_name: String
+
+    :param txn_id: A unique string supplied by the client to track the call through logs
+    :type txn_id: String
     """
+    logger = get_task_logger(txn_id=txn_id, task_id=self.request.id, loglevel=const.VLAB_ONEFS_LOG_LEVEL.upper())
     resp = {'content' : {}, 'error': None, 'params': {}}
     logger.info('Task starting')
     try:
@@ -91,15 +101,19 @@ def delete(username, machine_name):
     return resp
 
 
-@app.task(name='onefs.image')
-def image():
-    """TODO
+@app.task(name='onefs.image', bind=True)
+def image(self, txn_id):
+    """Obtain the available OneFS images/versions that can be deployed
 
     :Returns: Dictionary
 
     :param username: The name of the user who wants to create a new default gateway
     :type username: String
+
+    :param txn_id: A unique string supplied by the client to track the call through logs
+    :type txn_id: String
     """
+    logger = get_task_logger(txn_id=txn_id, task_id=self.request.id, loglevel=const.VLAB_ONEFS_LOG_LEVEL.upper())
     resp = {'content' : {}, 'error': None, 'params': {}}
     logger.info('Task starting')
     resp['content'] = {'image': vmware.list_images()}
@@ -107,10 +121,10 @@ def image():
     return resp
 
 
-@app.task(name='onefs.config')
-def config(cluster_name, name, username, version, int_netmask, int_ip_low,
+@app.task(name='onefs.config', bind=True)
+def config(self, cluster_name, name, username, version, int_netmask, int_ip_low,
            int_ip_high, ext_netmask, ext_ip_low, ext_ip_high, gateway, dns_servers,
-           encoding, sc_zonename, smartconnect_ip, join_cluster):
+           encoding, sc_zonename, smartconnect_ip, join_cluster, txn_id):
     """Turn a blank OneFS node into a usable device
 
     :Returns: Dictionary
@@ -153,7 +167,11 @@ def config(cluster_name, name, username, version, int_netmask, int_ip_low,
 
     :param join_cluster: Add the node to an existing cluster
     :type join_cluster: Boolean
+
+    :param txn_id: A unique string supplied by the client to track the call through logs
+    :type txn_id: String
     """
+    logger = get_task_logger(txn_id=txn_id, task_id=self.request.id, loglevel=const.VLAB_ONEFS_LOG_LEVEL.upper())
     resp = {'content' : {}, 'error': None, 'params': {}}
     logger.info('Task starting')
     nodes =  vmware.show_onefs(username)

--- a/vlab_onefs_api/lib/worker/tasks.py
+++ b/vlab_onefs_api/lib/worker/tasks.py
@@ -163,29 +163,35 @@ def config(cluster_name, name, username, version, int_netmask, int_ip_low,
         resp['error'] = error
         logger.error(error)
         return resp
-    # Lets set it up!
-    logger.info('Found node')
-    console_url = node['console']
-    if join_cluster:
-        logger.info('Joining node to cluster {}'.format(cluster_name))
-        setup_onefs.join_existing_cluster(console_url, cluster_name, logger)
+    elif node['info']['configured']:
+        error = "Cannot configure a node that's already configured"
+        resp['error'] = error
+        logger.error(error)
     else:
-        logger.info('Setting up new cluster named {}'.format(cluster_name))
-        setup_onefs.configure_new_cluster(version=version,
-                                          console_url=console_url,
-                                          cluster_name=cluster_name,
-                                          int_netmask=int_netmask,
-                                          int_ip_low=int_ip_low,
-                                          int_ip_high=int_ip_high,
-                                          ext_netmask=ext_netmask,
-                                          ext_ip_low=ext_ip_low,
-                                          ext_ip_high=ext_ip_high,
-                                          gateway=gateway,
-                                          dns_servers=dns_servers,
-                                          encoding=encoding,
-                                          sc_zonename=sc_zonename,
-                                          smartconnect_ip=smartconnect_ip,
-                                          logger=logger)
-
+        # Lets set it up!
+        logger.info('Found node')
+        console_url = node['console']
+        if join_cluster:
+            logger.info('Joining node to cluster {}'.format(cluster_name))
+            setup_onefs.join_existing_cluster(console_url, cluster_name, logger)
+        else:
+            logger.info('Setting up new cluster named {}'.format(cluster_name))
+            setup_onefs.configure_new_cluster(version=version,
+                                              console_url=console_url,
+                                              cluster_name=cluster_name,
+                                              int_netmask=int_netmask,
+                                              int_ip_low=int_ip_low,
+                                              int_ip_high=int_ip_high,
+                                              ext_netmask=ext_netmask,
+                                              ext_ip_low=ext_ip_low,
+                                              ext_ip_high=ext_ip_high,
+                                              gateway=gateway,
+                                              dns_servers=dns_servers,
+                                              encoding=encoding,
+                                              sc_zonename=sc_zonename,
+                                              smartconnect_ip=smartconnect_ip,
+                                              logger=logger)
+    node['info']['configured'] = True
+    vmware.update_meta(username, name, node['info'])
     logger.info('Task complete')
     return resp

--- a/vlab_onefs_api/lib/worker/vmware.py
+++ b/vlab_onefs_api/lib/worker/vmware.py
@@ -3,16 +3,11 @@
 import time
 import random
 import os.path
-from celery.utils.log import get_task_logger
 from vlab_inf_common.vmware import vCenter, Ova, vim, virtual_machine, consume_task
 
 import ujson
 
 from vlab_onefs_api.lib import const
-
-
-logger = get_task_logger(__name__)
-logger.setLevel(const.VLAB_ONEFS_LOG_LEVEL.upper())
 
 
 def show_onefs(username):
@@ -34,7 +29,7 @@ def show_onefs(username):
     return onefs_vms
 
 
-def delete_onefs(username, machine_name):
+def delete_onefs(username, machine_name, logger):
     """Unregister and destroy a user's onefs node
 
     :Returns: None
@@ -44,6 +39,9 @@ def delete_onefs(username, machine_name):
 
     :param machine_name: The name of the VM to delete
     :type machine_name: String
+
+    :param logger: An object for logging messages
+    :type logger: logging.LoggerAdapter
     """
     with vCenter(host=const.INF_VCENTER_SERVER, user=const.INF_VCENTER_USER, \
                  password=const.INF_VCENTER_PASSWORD) as vcenter:
@@ -62,7 +60,7 @@ def delete_onefs(username, machine_name):
             raise ValueError('No OneFS node named {} found'.format(machine_name))
 
 
-def create_onefs(username, machine_name, image, front_end, back_end):
+def create_onefs(username, machine_name, image, front_end, back_end, logger):
     """Deploy a OneFS node
 
     :Returns: Dictionary
@@ -81,6 +79,9 @@ def create_onefs(username, machine_name, image, front_end, back_end):
 
     :param back_end: The network to hook the internal network to
     :type back_end: String
+
+    :param logger: An object for logging messages
+    :type logger: logging.LoggerAdapter
     """
     with vCenter(host=const.INF_VCENTER_SERVER, user=const.INF_VCENTER_USER, \
                  password=const.INF_VCENTER_PASSWORD) as vcenter:

--- a/vlab_onefs_api/lib/worker/vmware.py
+++ b/vlab_onefs_api/lib/worker/vmware.py
@@ -86,7 +86,11 @@ def create_onefs(username, machine_name, image, front_end, back_end):
     with vCenter(host=const.INF_VCENTER_SERVER, user=const.INF_VCENTER_USER, \
                  password=const.INF_VCENTER_PASSWORD) as vcenter:
         ova_name = convert_name(image)
-        ova = Ova(os.path.join(const.VLAB_ONEFS_IMAGES_DIR, ova_name))
+        try:
+            ova = Ova(os.path.join(const.VLAB_ONEFS_IMAGES_DIR, ova_name))
+        except FileNotFoundError:
+            error = 'Invalid version of OneFS: {}'.format(convert_name(image, to_version=True))
+            raise ValueError(error)
         try:
             network_map = make_network_map(vcenter.networks, front_end, back_end)
             the_vm = virtual_machine.deploy_from_ova(vcenter=vcenter,

--- a/vlab_onefs_api/lib/worker/vmware.py
+++ b/vlab_onefs_api/lib/worker/vmware.py
@@ -88,7 +88,7 @@ def create_onefs(username, machine_name, image, front_end, back_end):
         try:
             ova = Ova(os.path.join(const.VLAB_ONEFS_IMAGES_DIR, ova_name))
         except FileNotFoundError:
-            error = 'Invalid version of OneFS: {}'.format(convert_name(image, to_version=True))
+            error = 'Invalid version of OneFS: {}'.format(image)
             raise ValueError(error)
         try:
             network_map = make_network_map(vcenter.networks, front_end, back_end)


### PR DESCRIPTION
This PR fixes an issue where the API would respond with 200 OK when a node is configured, regardless if the config has already been done. This "double config" is nonsense because you can only walk through the OneFS configuration wizard once, so the API responding OK to subsequent config requests is wrong.

While down in the depths to fix this bug, I shaved some additional Yaks. Most notably the terrible error message returned when asked to deploy a garbage OneFS version, and added the client request id to the backend logging.