### PR TITLE
pause after some section to allow OneFS wizard to process section

### DIFF
--- a/tests/test_setup_onefs.py
+++ b/tests/test_setup_onefs.py
@@ -316,7 +316,8 @@ class TestWizardRoutines(unittest.TestCase):
 
         self.assertEqual(output, expected)
 
-    def test_set_passwords(self):
+    @patch.object(setup_onefs.time, 'sleep')
+    def test_set_passwords(self, fake_sleep):
         """``set_passwords`` returns None"""
         output = setup_onefs.set_passwords(self.fake_console)
         expected = None
@@ -337,14 +338,16 @@ class TestWizardRoutines(unittest.TestCase):
 
         self.assertEqual(output, expected)
 
-    def test_set_encoding(self):
+    @patch.object(setup_onefs.time, 'sleep')
+    def test_set_encoding(self, fake_sleep):
         """``set_encoding`` returns None"""
         output = setup_onefs.set_encoding(self.fake_console, 'utf-8')
         expected = None
 
         self.assertEqual(output, expected)
 
-    def test_config_network(self):
+    @patch.object(setup_onefs.time, 'sleep')
+    def test_config_network(self, fake_sleep):
         """``config_network`` returns None"""
         output = setup_onefs.config_network(self.fake_console,
                                             netmask='255.255.255.0',

--- a/vlab_onefs_api/lib/worker/setup_onefs.py
+++ b/vlab_onefs_api/lib/worker/setup_onefs.py
@@ -15,6 +15,7 @@ from vlab_onefs_api.lib import const
 BOOT_WAIT = 60   # dumb sleep while waiting for the node to fully boot
 FORMAT_WAIT = 90 # dumb sleep waiting for the new VMDKs for format
 BUILD_WAIT = 90  # dumb sleep while OneFS applies the new config
+SECTION_PROCESS_PAUSE = 2 # allow the wizard to process a section, before moving onto the next one
 
 # Compliance mode license: http://licensing.west.isilon.com/internal-license.php?modules=0xfffff
 
@@ -385,6 +386,7 @@ def set_passwords(console, root='a', admin='a'):
     console.send_keys(admin)
     # Confirm admin password
     console.send_keys(admin)
+    time.sleep(SECTION_PROCESS_PAUSE)
 
 
 def set_esrs(console, enabled='no'):
@@ -426,6 +428,7 @@ def set_encoding(console, encoding):
         'latin-10' : '22'
     }
     console.send_keys(mapping[encoding.lower()])
+    time.sleep(SECTION_PROCESS_PAUSE)
 
 
 def config_network(console, netmask, ip_low, ip_high, ext_network=False):
@@ -451,6 +454,7 @@ def config_network(console, netmask, ip_low, ip_high, ext_network=False):
     console.send_keys(Keys.ENTER, auto_enter=False)
     console.send_keys(Keys.ENTER, auto_enter=False)
     console.send_keys(Keys.ENTER, auto_enter=False)
+    time.sleep(SECTION_PROCESS_PAUSE)
 
 
 def set_default_gateway(console, gateway):


### PR DESCRIPTION
After watching the automation walk through the wizard a few dozen times, I noticed the OneFS config wizard sometimes _hiccups_ after completing a section. Not sure what's up with _why_ the config wizard does this, and even if I knew, I wouldn't be able to do anything about it. So we have to work around it.

This PR adds some section sleeps after a few sections that I noticed _hiccup_. Between these, and the normal pause of the Selenium object, the config wizard should have plenty of time to finish whatever it's doing.