### PR TITLE
Bug: compairing string is a bad idea

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-onefs-api",
       author="Nicholas Willhite,",
       author_email='willnx84@gmail.com',
-      version='2019.01.03',
+      version='2019.01.04',
       packages=find_packages(),
       include_package_data=True,
       package_files={'vlab_onefs_api' : ['app.ini']},

--- a/vlab_onefs_api/lib/validators.py
+++ b/vlab_onefs_api/lib/validators.py
@@ -180,7 +180,7 @@ def validate_ip_range(ip_low, ip_high, group):
 
     :Raises: ValueError
     """
-    if not ip_low <= ip_high:
+    if not ipaddress.IPv4Address(ip_low) <= ipaddress.IPv4Address(ip_high):
         error = 'IP {} larger than top of IP range {} for {}'.format(ip_low, ip_high, group)
         raise ValueError(error)
 


### PR DESCRIPTION
This PR is in response to https://github.com/willnx/vlab/issues/5

For example:
```
>>> '9' > '10'
True
```

I manually looked through the code to see if I was doing something _wonky_ with the high vs low internal IPs, like inverting positional args; no dice. Not 100% sure that this is the problem, or if it'll even catch the problem. If it doesn't catch the issue, then I know it's something on the server side _after_ input validation.
