### PR TITLE
validator catches hostname that do not start with a letter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-onefs-api",
       author="Nicholas Willhite,",
       author_email='willnx84@gmail.com',
-      version='2019.01.04',
+      version='2019.01.22',
       packages=find_packages(),
       include_package_data=True,
       package_files={'vlab_onefs_api' : ['app.ini']},

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -115,6 +115,11 @@ class TestValidaters(unittest.TestCase):
         with self.assertRaises(ValueError):
             validators.validate_names(hostname='sdf.foo_bar.com', group='cluster name')
 
+    def test_validate_names_not_alpha(self):
+        """``validate_names`` raises ValueError if the hostname does not start with a letter"""
+        with self.assertRaises(ValueError):
+            validators.validate_names(hostname='-sdf.foo_bar.com', group='cluster name')
+
     def test_validate_ips(self):
         """``validate_ips`` returns None upon success"""
         output = validators.validate_ips('192.168.1.1', '10.7.1.2', group='front end network')

--- a/vlab_onefs_api/lib/validators.py
+++ b/vlab_onefs_api/lib/validators.py
@@ -131,18 +131,16 @@ def validate_names(hostname, group):
     if len(hostname) < 1:
         ok = False
         error = 'Cluster name cannot be empty'
-    else:
-        try:
-            int(hostname[0])
-            ok = False # hostname cannot start with a number
-        except ValueError:
-            # OneFS recommends limiting names to 11 chars for NetBIOS compatibility
-            if len(hostname) > 11:
-                ok = False
-                error = 'Cluster name cannot exceed 11 letters'
-            elif not all(allowed.match(x) for x in hostname.split(".")):
-                ok = False
-                error = 'Invalid name of {} supplied for {}'.format(hostname, group)
+    elif not hostname[0].isalpha():
+        error = 'Cluster name must start with a letter, supplied name {}'.format(hostname)
+        ok = False
+    # OneFS recommends limiting names to 11 chars for NetBIOS compatibility
+    elif len(hostname) > 11:
+        ok = False
+        error = 'Cluster name cannot exceed 11 letters'
+    elif not all(allowed.match(x) for x in hostname.split(".")):
+        ok = False
+        error = 'Invalid name of {} supplied for {}'.format(hostname, group)
     if not ok:
         raise ValueError(error)
 


### PR DESCRIPTION
Hostnames must start with a letter. OneFS knows this, but vLab did not enforce it. This would lead to failed auto-configured OneFS deployments

![image](https://user-images.githubusercontent.com/12264343/51553331-68a96300-1e27-11e9-87e5-8791c1b71bc9.png)
