### PR TITLE
Automation waits 2min30sec now for the cluster to form

### DIFF
--- a/vlab_onefs_api/lib/worker/setup_onefs.py
+++ b/vlab_onefs_api/lib/worker/setup_onefs.py
@@ -14,7 +14,7 @@ from vlab_onefs_api.lib import const
 
 BOOT_WAIT = 60   # dumb sleep while waiting for the node to fully boot
 FORMAT_WAIT = 90 # dumb sleep waiting for the new VMDKs for format
-BUILD_WAIT = 90  # dumb sleep while OneFS applies the new config
+BUILD_WAIT = 150  # dumb sleep while OneFS applies the new config
 SECTION_PROCESS_PAUSE = 2 # allow the wizard to process a section, before moving onto the next one
 
 # Compliance mode license: http://licensing.west.isilon.com/internal-license.php?modules=0xfffff


### PR DESCRIPTION
A few users have noticed that vLab fails to join all OneFS nodes when making a cluster:
https://github.com/willnx/vlab/issues/14

When I dig into it, for some reason node 2 timesout when trying to join node 1. However, in every case, the next node created by vLab successfully joins. 

This makes me think that, for some reason, completion of the OneFS config wizard where it takes the user input and forms the 1-node cluster simply takes longer than expected. A simple increase in the amount of time we wait for that 1-node to form should address the problem if I'm correct.