### PR TITLE
the vSphereConsole object now blocks until the login is complete

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-onefs-api",
       author="Nicholas Willhite,",
       author_email='willnx84@gmail.com',
-      version='2019.02.22',
+      version='2019.04.19',
       packages=find_packages(),
       include_package_data=True,
       package_files={'vlab_onefs_api' : ['app.ini']},

--- a/vlab_onefs_api/lib/worker/setup_onefs.py
+++ b/vlab_onefs_api/lib/worker/setup_onefs.py
@@ -25,9 +25,10 @@ class vSphereConsole(object):
     def __init__(self, url, username=const.INF_VCENTER_READONLY_USER, headless=True,
                  password=const.INF_VCENTER_READONLY_PASSWORD):
         options = Options()
-        options.headless = headless
+        #options.headless = headless
         self._driver = webdriver.Firefox(options=options, service_log_path='/var/log/webdriver.log')
-        login_page = 'https://{}/ui'.format(const.INF_VCENTER_SERVER)
+        #login_page = 'https://{}/ui'.format(const.INF_VCENTER_SERVER)
+        login_page = 'https://vlab-vcenter.emc.com/ui'
         self._username = username
         self._password = password
         self._driver.get(login_page)
@@ -44,6 +45,11 @@ class vSphereConsole(object):
         password_field.send_keys(self._password)
         login_button = self._driver.find_element_by_id('submit')
         login_button.click()
+        # Waits for the login to complete; avoids race between getting auth cookie
+        # and attempting to access the HTML console
+        WebDriverWait(self._driver, 30).until(
+            EC.presence_of_element_located((By.ID, "MainTemplateController"))
+        )
 
     def _get_console(self, url):
         self._driver.get(url)

--- a/vlab_onefs_api/lib/worker/setup_onefs.py
+++ b/vlab_onefs_api/lib/worker/setup_onefs.py
@@ -25,10 +25,9 @@ class vSphereConsole(object):
     def __init__(self, url, username=const.INF_VCENTER_READONLY_USER, headless=True,
                  password=const.INF_VCENTER_READONLY_PASSWORD):
         options = Options()
-        #options.headless = headless
+        options.headless = headless
         self._driver = webdriver.Firefox(options=options, service_log_path='/var/log/webdriver.log')
-        #login_page = 'https://{}/ui'.format(const.INF_VCENTER_SERVER)
-        login_page = 'https://vlab-vcenter.emc.com/ui'
+        login_page = 'https://{}/ui'.format(const.INF_VCENTER_SERVER)
         self._username = username
         self._password = password
         self._driver.get(login_page)


### PR DESCRIPTION
Fixes issue https://github.com/willnx/vlab/issues/16

Not sure why, but the new fancy login page for vCenter is much slower.
While testing, I saw that the automation would click the "submit" button, then immediately switch to the HTML console and get an unauthorized error.

After adding a wait to let some of the vCenter page to load before switching to the console, I was able to successfully open the HTML console page.