### PR TITLE
Service can now make a compliance mode cluster

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-onefs-api",
       author="Nicholas Willhite,",
       author_email='willnx84@gmail.com',
-      version='2019.04.06',
+      version='2019.05.08',
       packages=find_packages(),
       include_package_data=True,
       package_files={'vlab_onefs_api' : ['app.ini']},

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -113,6 +113,7 @@ class TestTasks(unittest.TestCase):
                               sc_zonename='myzone.foo.com',
                               smartconnect_ip='10.1.1.21',
                               join_cluster=False,
+                              compliance=False,
                               txn_id='myId')
         expected = {'content': {}, 'error': None, 'params': {}}
 
@@ -141,6 +142,7 @@ class TestTasks(unittest.TestCase):
                               sc_zonename='myzone.foo.com',
                               smartconnect_ip='10.1.1.21',
                               join_cluster=True,
+                              compliance=False,
                               txn_id='myId')
         expected = {'content': {}, 'error': None, 'params': {}}
 
@@ -168,6 +170,7 @@ class TestTasks(unittest.TestCase):
                               sc_zonename='myzone.foo.com',
                               smartconnect_ip='10.1.1.21',
                               join_cluster=False,
+                              compliance=False,
                               txn_id='myId')
         expected = {'content': {}, 'error': 'No node named mycluster-1 found', 'params': {}}
 
@@ -197,6 +200,7 @@ class TestTasks(unittest.TestCase):
                               sc_zonename='myzone.foo.com',
                               smartconnect_ip='10.1.1.21',
                               join_cluster=False,
+                              compliance=False,
                               txn_id='myId')
         expected = {'content': {}, 'error': "Cannot configure a node that's already configured", 'params': {}}
 

--- a/vlab_onefs_api/lib/constants.py
+++ b/vlab_onefs_api/lib/constants.py
@@ -26,6 +26,7 @@ DEFINED = OrderedDict([
             ('INF_VCENTER_READONLY_USER', environ.get('INF_VCENTER_READONLY_USER', 'readonly@vsphere.local')),
             ('INF_VCENTER_READONLY_PASSWORD', environ.get('INF_VCENTER_READONLY_PASSWORD', 'a')),
             ('VLAB_VERIFY_TOKEN', environ.get('VLAB_VERIFY_TOKEN', False)),
+            ('INTERAL_LICENSE_SERVER', environ.get('INTERAL_LICENSE_SERVER', 'http://some.server.org'))
           ])
 
 Constants = namedtuple('Constants', list(DEFINED.keys()))

--- a/vlab_onefs_api/lib/views/onefs.py
+++ b/vlab_onefs_api/lib/views/onefs.py
@@ -130,6 +130,11 @@ class OneFSView(TaskView):
                             "description": "The SIP to configure on the external network. Empty string is valid",
                             "type": "string"
                         },
+                        "compliance": {
+                            "description" : "Enable compliance mode",
+                            "type": "boolean",
+                            "default": "false",
+                        },
                         "encoding": {
                             "description": "The filesystem encoding to use.",
                             "type": "string",
@@ -251,6 +256,7 @@ class OneFSView(TaskView):
         sc_zonename     = kwargs['body'].get('sc_zonename', None)
         smartconnect_ip = kwargs['body'].get('smartconnect_ip', None)
         join_cluster    = kwargs['body'].get('join', False)
+        compliance      = kwargs['body'].get('compliance', False)
         dns_servers     = ','.join(kwargs['body'].get('dns_servers', []))
         # Ensure supplied values wont generate an error in the OneFS config wizard
         error = supplied_config_values_are_valid(int_netmask=int_netmask,
@@ -286,6 +292,7 @@ class OneFSView(TaskView):
                                                                             'sc_zonename' : sc_zonename,
                                                                             'smartconnect_ip' : smartconnect_ip,
                                                                             'join_cluster' : join_cluster,
+                                                                            'compliance' : compliance,
                                                                             'txn_id' : txn_id})
 
             resp_data['content'] = {'task-id': task.id}

--- a/vlab_onefs_api/lib/worker/tasks.py
+++ b/vlab_onefs_api/lib/worker/tasks.py
@@ -124,7 +124,7 @@ def image(self, txn_id):
 @app.task(name='onefs.config', bind=True)
 def config(self, cluster_name, name, username, version, int_netmask, int_ip_low,
            int_ip_high, ext_netmask, ext_ip_low, ext_ip_high, gateway, dns_servers,
-           encoding, sc_zonename, smartconnect_ip, join_cluster, txn_id):
+           encoding, sc_zonename, smartconnect_ip, join_cluster, compliance, txn_id):
     """Turn a blank OneFS node into a usable device
 
     :Returns: Dictionary
@@ -168,6 +168,9 @@ def config(self, cluster_name, name, username, version, int_netmask, int_ip_low,
     :param join_cluster: Add the node to an existing cluster
     :type join_cluster: Boolean
 
+    :param compliance: Set to True when creating a Compliance mode cluster
+    :type compliance: Boolean
+
     :param txn_id: A unique string supplied by the client to track the call through logs
     :type txn_id: String
     """
@@ -191,7 +194,7 @@ def config(self, cluster_name, name, username, version, int_netmask, int_ip_low,
         console_url = node['console']
         if join_cluster:
             logger.info('Joining node to cluster {}'.format(cluster_name))
-            setup_onefs.join_existing_cluster(console_url, cluster_name, logger)
+            setup_onefs.join_existing_cluster(console_url, cluster_name, compliance, logger)
         else:
             logger.info('Setting up new cluster named {}'.format(cluster_name))
             setup_onefs.configure_new_cluster(version=version,
@@ -208,6 +211,7 @@ def config(self, cluster_name, name, username, version, int_netmask, int_ip_low,
                                               encoding=encoding,
                                               sc_zonename=sc_zonename,
                                               smartconnect_ip=smartconnect_ip,
+                                              compliance=compliance,
                                               logger=logger)
     node['meta']['configured'] = True
     vmware.update_meta(username, name, node['meta'])


### PR DESCRIPTION
When deploying a cluster, you can supply the API with the param `compliance` which is a boolean that defaults to False.

This functionality is needed as the first part of https://github.com/willnx/vlab/issues/25

I've manually verified that the auto-config logic will create a compliance mode cluster, as well as join a node to compliance mode cluster. Would be a good idea to test several versions of OneFS before rolling out into production.