### PR TITLE
service uses 'adjust_ram' from vlab-inf-common package now

### DIFF
--- a/tests/test_vmware.py
+++ b/tests/test_vmware.py
@@ -58,6 +58,7 @@ class TestVMware(unittest.TestCase):
 
         self.assertEqual(output, expected)
 
+    @patch.object(vmware.virtual_machine, 'adjust_ram')
     @patch.object(vmware.virtual_machine, 'set_meta')
     @patch.object(vmware, 'consume_task')
     @patch.object(vmware, 'make_network_map')
@@ -65,7 +66,7 @@ class TestVMware(unittest.TestCase):
     @patch.object(vmware.virtual_machine, 'get_info')
     @patch.object(vmware.virtual_machine, 'deploy_from_ova')
     @patch.object(vmware, 'vCenter')
-    def test_create_onefs(self, fake_vCenter, fake_deploy_from_ova, fake_get_info, fake_Ova, make_network_map, fake_consume_task, fake_set_meta):
+    def test_create_onefs(self, fake_vCenter, fake_deploy_from_ova, fake_get_info, fake_Ova, make_network_map, fake_consume_task, fake_set_meta, fake_adjust_ram):
         """``create_onefs`` returns the new onefs's info when everything works"""
         fake_logger = MagicMock()
         fake_Ova.return_value.networks = ['vLabNetwork']
@@ -181,6 +182,7 @@ class TestVMware(unittest.TestCase):
         with self.assertRaises(ValueError):
             vmware.delete_onefs(username='alice', machine_name='not a thing', logger=fake_logger)
 
+    @patch.object(vmware.virtual_machine, 'adjust_ram')
     @patch.object(vmware.virtual_machine, 'set_meta')
     @patch.object(vmware, 'consume_task')
     @patch.object(vmware, 'make_network_map')
@@ -188,7 +190,7 @@ class TestVMware(unittest.TestCase):
     @patch.object(vmware.virtual_machine, 'get_info')
     @patch.object(vmware.virtual_machine, 'deploy_from_ova')
     @patch.object(vmware, 'vCenter')
-    def test_create_onefs_power(self, fake_vCenter, fake_deploy_from_ova, fake_get_info, fake_Ova, make_network_map, fake_consume_task, fake_set_meta):
+    def test_create_onefs_power(self, fake_vCenter, fake_deploy_from_ova, fake_get_info, fake_Ova, make_network_map, fake_consume_task, fake_set_meta, fake_adjust_ram):
         """``create_onefs`` opts out of the deploy lib powering on the new VM"""
         fake_logger = MagicMock()
         fake_Ova.return_value.networks = ['vLabNetwork']
@@ -207,6 +209,7 @@ class TestVMware(unittest.TestCase):
 
         self.assertEqual(called_power, expected_power)
 
+    @patch.object(vmware.virtual_machine, 'adjust_ram')
     @patch.object(vmware.virtual_machine, 'power')
     @patch.object(vmware.virtual_machine, 'set_meta')
     @patch.object(vmware, 'consume_task')
@@ -215,7 +218,7 @@ class TestVMware(unittest.TestCase):
     @patch.object(vmware.virtual_machine, 'get_info')
     @patch.object(vmware.virtual_machine, 'deploy_from_ova')
     @patch.object(vmware, 'vCenter')
-    def test_create_onefs_power_false(self, fake_vCenter, fake_deploy_from_ova, fake_get_info, fake_Ova, make_network_map, fake_consume_task, fake_set_meta, fake_power):
+    def test_create_onefs_power_false(self, fake_vCenter, fake_deploy_from_ova, fake_get_info, fake_Ova, make_network_map, fake_consume_task, fake_set_meta, fake_power, fake_adjust_ram):
         """``create_onefs`` manually powers on the VM"""
         fake_logger = MagicMock()
         fake_Ova.return_value.networks = ['vLabNetwork']
@@ -234,7 +237,7 @@ class TestVMware(unittest.TestCase):
 
         self.assertEqual(called_power, expected_power)
 
-    @patch.object(vmware, 'adjust_ram')
+    @patch.object(vmware.virtual_machine, 'adjust_ram')
     @patch.object(vmware.virtual_machine, 'set_meta')
     @patch.object(vmware, 'consume_task')
     @patch.object(vmware, 'make_network_map')

--- a/vlab_onefs_api/lib/worker/vmware.py
+++ b/vlab_onefs_api/lib/worker/vmware.py
@@ -103,7 +103,7 @@ def create_onefs(username, machine_name, image, front_end, back_end, logger):
         finally:
             ova.close()
         # The OVA ships with ~2GB of RAM. The vOneFS docs recommend 6GB for heavy load.
-        adjust_ram(the_vm, mb_of_ram=4096)
+        virtual_machine.adjust_ram(the_vm, mb_of_ram=4096)
         virtual_machine.power(the_vm, state='on')
         meta_data = {'component': 'OneFS',
                      'created': time.time(),
@@ -192,20 +192,3 @@ def make_network_map(vcenter_networks, front_end, back_end):
             raise ValueError(error)
         net_map.append(map)
     return net_map
-
-
-def adjust_ram(vm, mb_of_ram=4096):
-    """Set the amount of RAM for a powered-off VM
-
-    :Returns: None
-
-    :param vm: The virtual machine to adjust
-    :type vm: vim.VirtualMachine
-
-    :param mb_of_ram: The number of MB of RAM/memory to give the virtual machine
-    :type mb_of_ram: Integer
-    """
-    config_spec = vim.vm.ConfigSpec()
-    config_spec.memoryMB = mb_of_ram
-
-    consume_task(vm.Reconfigure(config_spec))


### PR DESCRIPTION
In response to https://github.com/willnx/vlab_inf_common/pull/30

Updated this service to use the centralized function to adjust VM RAM.