### PR TITLE
Service now supports changing the frontend network of a OneFS node

### DIFF
--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -207,5 +207,31 @@ class TestTasks(unittest.TestCase):
         self.assertEqual(output, expected)
 
 
+    @patch.object(tasks, 'vmware')
+    def test_modify_network(self, fake_vmware):
+        """``modify_network`` returns an empty content dictionary upon success"""
+        output = tasks.modify_network(username='pat',
+                                      machine_name='myOneFS',
+                                      new_network='wootTown',
+                                      txn_id='someTransactionID')
+        expected = {'content': {}, 'error': None, 'params': {}}
+
+        self.assertEqual(output, expected)
+
+    @patch.object(tasks, 'vmware')
+    def test_modify_network_error(self, fake_vmware):
+        """``modify_network`` Catches ValueError, and sets the response accordingly"""
+        fake_vmware.update_network.side_effect = ValueError('some bad input')
+
+        output = tasks.modify_network(username='pat',
+                                      machine_name='myOneFS',
+                                      new_network='wootTown',
+                                      txn_id='someTransactionID')
+
+        expected = {'content': {}, 'error': 'some bad input', 'params': {}}
+
+        self.assertEqual(output, expected)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_vmware.py
+++ b/tests/test_vmware.py
@@ -314,6 +314,66 @@ class TestVMware(unittest.TestCase):
 
         self.assertTrue(fake_set_meta.called)
 
+    @patch.object(vmware.virtual_machine, 'change_network')
+    @patch.object(vmware.virtual_machine, 'get_info')
+    @patch.object(vmware, 'consume_task')
+    @patch.object(vmware, 'vCenter')
+    def test_update_network(self, fake_vCenter, fake_consume_task, fake_get_info, fake_change_network):
+        """``update_network`` Returns None upon success"""
+        fake_logger = MagicMock()
+        fake_vm = MagicMock()
+        fake_vm.name = 'myOneFS'
+        fake_folder = MagicMock()
+        fake_folder.childEntity = [fake_vm]
+        fake_vCenter.return_value.__enter__.return_value.get_by_name.return_value = fake_folder
+        fake_vCenter.return_value.__enter__.return_value.networks = {'wootTown' : 'someNetworkObject'}
+        fake_get_info.return_value = {'meta': {'component' : 'OneFS'}}
+
+        result = vmware.update_network(username='pat',
+                                       machine_name='myOneFS',
+                                       new_network='wootTown')
+
+        self.assertTrue(result is None)
+
+    @patch.object(vmware.virtual_machine, 'change_network')
+    @patch.object(vmware.virtual_machine, 'get_info')
+    @patch.object(vmware, 'consume_task')
+    @patch.object(vmware, 'vCenter')
+    def test_update_network_no_vm(self, fake_vCenter, fake_consume_task, fake_get_info, fake_change_network):
+        """``update_network`` Raises ValueError if the supplied VM doesn't exist"""
+        fake_logger = MagicMock()
+        fake_vm = MagicMock()
+        fake_vm.name = 'myIIQ'
+        fake_folder = MagicMock()
+        fake_folder.childEntity = [fake_vm]
+        fake_vCenter.return_value.__enter__.return_value.get_by_name.return_value = fake_folder
+        fake_vCenter.return_value.__enter__.return_value.networks = {'wootTown' : 'someNetworkObject'}
+        fake_get_info.return_value = {'meta': {'component' : 'OneFS'}}
+
+        with self.assertRaises(ValueError):
+            vmware.update_network(username='pat',
+                                  machine_name='SomeOtherMachine',
+                                  new_network='wootTown')
+
+    @patch.object(vmware.virtual_machine, 'change_network')
+    @patch.object(vmware.virtual_machine, 'get_info')
+    @patch.object(vmware, 'consume_task')
+    @patch.object(vmware, 'vCenter')
+    def test_update_network_no_network(self, fake_vCenter, fake_consume_task, fake_get_info, fake_change_network):
+        """``update_network`` Raises ValueError if the supplied new network doesn't exist"""
+        fake_logger = MagicMock()
+        fake_vm = MagicMock()
+        fake_vm.name = 'myOneFS'
+        fake_folder = MagicMock()
+        fake_folder.childEntity = [fake_vm]
+        fake_vCenter.return_value.__enter__.return_value.get_by_name.return_value = fake_folder
+        fake_vCenter.return_value.__enter__.return_value.networks = {'wootTown' : 'someNetworkObject'}
+        fake_get_info.return_value = {'meta': {'component' : 'OneFS'}}
+
+        with self.assertRaises(ValueError):
+            vmware.update_network(username='pat',
+                                  machine_name='myOneFS',
+                                  new_network='dohNet')
 
 
 if __name__ == '__main__':

--- a/vlab_onefs_api/lib/views/onefs.py
+++ b/vlab_onefs_api/lib/views/onefs.py
@@ -9,7 +9,7 @@ from socket import inet_aton
 import ujson
 from flask import current_app
 from flask_classy import request, route, Response
-from vlab_inf_common.views import TaskView
+from vlab_inf_common.views import MachineView
 from vlab_inf_common.vmware import vCenter, vim
 from vlab_api_common import describe, get_logger, requires, validate_input
 
@@ -21,9 +21,10 @@ from vlab_onefs_api.lib.validators import supplied_config_values_are_valid
 logger = get_logger(__name__, loglevel=const.VLAB_ONEFS_LOG_LEVEL)
 
 
-class OneFSView(TaskView):
+class OneFSView(MachineView):
     """API end point for working with OneFS nodes"""
     route_base = '/api/1/inf/onefs'
+    RESOURCE = 'onefs'
     POST_SCHEMA = { "$schema": "http://json-schema.org/draft-04/schema#",
                     "type": "object",
                     "description": "Create a new vOneFS node",

--- a/vlab_onefs_api/lib/worker/tasks.py
+++ b/vlab_onefs_api/lib/worker/tasks.py
@@ -217,3 +217,18 @@ def config(self, cluster_name, name, username, version, int_netmask, int_ip_low,
     vmware.update_meta(username, name, node['meta'])
     logger.info('Task complete')
     return resp
+
+
+@app.task(name='onefs.modify_network', bind=True)
+def modify_network(self, username, machine_name, new_network, txn_id):
+    """Change the network an OneFS node is connected to"""
+    logger = get_task_logger(txn_id=txn_id, task_id=self.request.id, loglevel=const.VLAB_ONEFS_LOG_LEVEL.upper())
+    resp = {'content' : {}, 'error': None, 'params': {}}
+    logger.info('Task starting')
+    try:
+        vmware.update_network(username, machine_name, new_network)
+    except ValueError as doh:
+        logger.error('Task failed: {}'.format(doh))
+        resp['error'] = '{}'.format(doh)
+    logger.info('Task complete')
+    return resp


### PR DESCRIPTION
Forgot to update the dev branch I was using...

Anyway, this PR updates the service to support https://github.com/willnx/vlab/issues/29