### PR TITLE
Server rejects OneFS node names with dots in them now

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -93,6 +93,11 @@ class TestValidaters(unittest.TestCase):
 
         self.assertEqual(output, expected)
 
+    def test_validate_names_dots(self):
+        """``validate_names`` raises ValueError if the hostname contains dots '.'"""
+        with self.assertRaises(ValueError):
+            validators.validate_names('v8.0.0.7-1', 'v8.0.0.7')
+
     def test_validate_names_too_long(self):
         """``validate_names`` raises ValueError if the hostname is too long"""
         with self.assertRaises(ValueError):
@@ -202,7 +207,7 @@ class TestValidaters(unittest.TestCase):
                                                                 smartconnect_ip='',
                                                                 gateway='',
                                                                 join_cluster=True)
-        expected = 'Invalid name of my_cluster supplied for cluster name'
+        expected = 'Invalid hostname of my_cluster supplied for cluster name'
         self.assertEqual(error_msg, expected)
 
     def test_supplied_config_values_are_valid_bad_value(self):

--- a/vlab_onefs_api/lib/validators.py
+++ b/vlab_onefs_api/lib/validators.py
@@ -138,9 +138,12 @@ def validate_names(hostname, group):
     elif len(hostname) > 11:
         ok = False
         error = 'Cluster name cannot exceed 11 letters'
+    elif '.' in hostname:
+        ok = False
+        error = 'OneFS nodes cannot have dots "." in their name. Supplied: {}'.format(hostname)
     elif not all(allowed.match(x) for x in hostname.split(".")):
         ok = False
-        error = 'Invalid name of {} supplied for {}'.format(hostname, group)
+        error = 'Invalid hostname of {} supplied for {}'.format(hostname, group)
     if not ok:
         raise ValueError(error)
 


### PR DESCRIPTION
This PR fixes https://github.com/willnx/vlab/issues/39 on the server side