### PR TITLE
Auto-config will set OneFS sysctls now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-onefs-api",
       author="Nicholas Willhite,",
       author_email='willnx84@gmail.com',
-      version='2020.01.30',
+      version='2020.03.03',
       packages=find_packages(),
       include_package_data=True,
       package_files={'vlab_onefs_api' : ['app.ini']},

--- a/tests/test_setup_onefs.py
+++ b/tests/test_setup_onefs.py
@@ -817,7 +817,7 @@ class TestWizardRoutines(unittest.TestCase):
         """``set_sysctls`` logins into the OneFS shell"""
         setup_onefs.set_sysctls(self.fake_console)
 
-        user, password, _, _ = self.fake_console.send_keys.call_args_list
+        user, password = self.fake_console.send_keys.call_args_list[:2]
         user = user[0][0] # pull the 1st positional arg
         password = password[0][0]
 
@@ -831,12 +831,21 @@ class TestWizardRoutines(unittest.TestCase):
         setup_onefs.set_sysctls(self.fake_console)
 
         sysctls = self.fake_console.send_keys.call_args_list[2:] # chop off the login
+        sysctls.pop() # chop off the exit
         sysctls = [x[0][0] for x in sysctls]
         expected = ['isi_sysctl_cluster kern.cam.da.default_timeout=180',
                     'isi_sysctl_cluster debug.debugger_on_panic=0']
         # sorted() to avoid false positive due to ordering
         self.assertEqual(sorted(sysctls), sorted(expected))
 
+    def test_set_sysctls_logs_out(self):
+        """``set_sysctls`` exits the terminal once done"""
+        setup_onefs.set_sysctls(self.fake_console)
+
+        exit = self.fake_console.send_keys.call_args_list[-1][0][0]
+        command = 'exit'
+
+        self.assertEqual(exit, command)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_setup_onefs.py
+++ b/tests/test_setup_onefs.py
@@ -813,6 +813,30 @@ class TestWizardRoutines(unittest.TestCase):
 
         self.assertEqual(license, expected)
 
+    def test_set_sysctls_logs_in(self):
+        """``set_sysctls`` logins into the OneFS shell"""
+        setup_onefs.set_sysctls(self.fake_console)
+
+        user, password, _, _ = self.fake_console.send_keys.call_args_list
+        user = user[0][0] # pull the 1st positional arg
+        password = password[0][0]
+
+        sent = (user, password)
+        expected = ('root', setup_onefs.DEFAULT_ROOT_PW)
+
+        self.assertEqual(sent, expected)
+
+    def test_set_sysctls(self):
+        """``set_sysctls`` sets the expected sysctls"""
+        setup_onefs.set_sysctls(self.fake_console)
+
+        sysctls = self.fake_console.send_keys.call_args_list[2:] # chop off the login
+        sysctls = [x[0][0] for x in sysctls]
+        expected = ['isi_sysctl_cluster kern.cam.da.default_timeout=180',
+                    'isi_sysctl_cluster debug.debugger_on_panic=0']
+        # sorted() to avoid false positive due to ordering
+        self.assertEqual(sorted(sysctls), sorted(expected))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/vlab_onefs_api/lib/worker/setup_onefs.py
+++ b/vlab_onefs_api/lib/worker/setup_onefs.py
@@ -814,3 +814,4 @@ def set_sysctls(console):
     # connections to the storage. At least with a boot loop, if you fix
     # the storage problem, the CPU usage problem can resolves itself.
     console.send_keys('isi_sysctl_cluster debug.debugger_on_panic=0')
+    console.send_keys('exit')

--- a/vlab_onefs_api/lib/worker/setup_onefs.py
+++ b/vlab_onefs_api/lib/worker/setup_onefs.py
@@ -13,6 +13,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from vlab_onefs_api.lib import const
 
 
+DEFAULT_ROOT_PW = 'a'
 SECTION_PROCESS_PAUSE = 2 # allow the wizard to process a section, before moving onto the next one
 
 
@@ -245,6 +246,7 @@ def configure_new_7_2_cluster(console_url, cluster_name, int_netmask, int_ip_low
         logger.info('Committing changes and waiting for the cluster to form')
         commit_config(console)
         console.wait_for_prompt(timeout=60) # isi firmware status --save is slow
+        set_sysctls(console)
 
 
 
@@ -335,6 +337,7 @@ def configure_new_8_0_cluster(console_url, cluster_name, int_netmask, int_ip_low
         logger.info('Committing changes and waiting for the cluster to form')
         commit_config(console)
         console.wait_for_prompt()
+        set_sysctls(console)
 
 
 def configure_new_8_1_cluster(console_url, cluster_name, int_netmask, int_ip_low, int_ip_high,
@@ -424,6 +427,7 @@ def configure_new_8_1_cluster(console_url, cluster_name, int_netmask, int_ip_low
         logger.info('Committing changes and waiting for the cluster to form')
         commit_config(console)
         console.wait_for_prompt()
+        set_sysctls(console)
 
 
 def configure_new_8_1_2_cluster(console_url, cluster_name, int_netmask, int_ip_low, int_ip_high,
@@ -519,6 +523,7 @@ def configure_new_8_1_2_cluster(console_url, cluster_name, int_netmask, int_ip_l
         logger.info('Committing changes and waiting for the cluster to form')
         commit_config(console)
         console.wait_for_prompt()
+        set_sysctls(console)
 
 
 def configure_new_8_2_0_cluster(console_url, cluster_name, int_netmask, int_ip_low, int_ip_high,
@@ -609,6 +614,7 @@ def configure_new_8_2_0_cluster(console_url, cluster_name, int_netmask, int_ip_l
         logger.info('Committing changes and waiting for the cluster to form')
         commit_config(console)
         console.wait_for_prompt()
+        set_sysctls(console)
 
 
 def format_disks(console):
@@ -642,7 +648,7 @@ def make_new_and_accept_eual(console, compliance_license, auto_enter=False):
     console.send_keys('yes')
 
 
-def set_passwords(console, root='a', admin='a'):
+def set_passwords(console, root=DEFAULT_ROOT_PW, admin='a'):
     """Set the root and admin user passwords"""
     # Set root password
     console.send_keys(root)
@@ -788,3 +794,23 @@ def get_compliance_license():
     resp = requests.get(const.INTERNAL_LICENSE_SERVER)
     license = resp.content.decode().strip()
     return license
+
+
+def set_sysctls(console):
+    """Configure persistent sysctls for OneFS, so it "plays nice" with vSphere"""
+    # Login to the shell
+    console.send_keys('root')
+    console.send_keys(DEFAULT_ROOT_PW)
+    # VMware Tools on a Linux VM increases the SCSI timeout from 90 to 180.
+    # OneFS does not support VMware Tools, so we have to manually adjust the
+    # value. If you don't set this, then when there's a delay in the storage
+    # on vSphere, OneFS will *increase* load on the storage which just makes
+    # things worse.
+    console.send_keys('isi_sysctl_cluster kern.cam.da.default_timeout=180')
+    # Reboot instead of dropping into the debugger.
+    # Both consume more CPU than an typical machine, but the debugger
+    # requires manual intervention to reduce CPU usage. This is really
+    # painful in a cascading failure, like if the ESXi host loses all
+    # connections to the storage. At least with a boot loop, if you fix
+    # the storage problem, the CPU usage problem can resolves itself.
+    console.send_keys('isi_sysctl_cluster debug.debugger_on_panic=0')


### PR DESCRIPTION
[OneFS](https://www.delltechnologies.com/en-us/storage/isilon/onefs-operating-system.htm#) is the most common VM deployed in my environment. I've been having some storage-related issues within my vSphere environment, and the point of this PR is to make OneFS deal with storage failures a bit more gracefully.

### sysctl kern.cam.da.default_timeout
Turns out, VMware Tools on Linux increases the SCSI timeout from 90 seconds to 180. OneFS is not compatible with VMware Tools, and has a default timeout of 60 seconds. While debugging my vSphere environment, I would notice the OneFS VMs to consume _a lot_ of CPU while _"idleing"_. Turns out, it was the kernel spinning the CPU to talk to the VMDKs. I tested increasing this timeout on a few OneFS VMs, and the CPU dropped back to normal/expected for an idle machine.

### debug.debugger_on_panic
This sysctl defines _what to do_ if a kernel panic happens. In my situation, the kernel was panicking because of the SCSI failures. Ideally, considering these are just labs, the VM would simply _power off_ if there was a kernel panic. That would prevent something like a loss of connection between ESXi and the SAN from cascading into a _the ESXi running out of CPU resource_ due to all the OneFS VMs on the host from falling into the debugger. When at the debugger, the VM spins the CPU to 100% awaiting keyboard input. At least with a potential boot loop, I don't have to _clean up the mess_ (i.e. reboot the OneFS VMs at the debugger) after fixing the storage connection issue 😅. 