### PR TITLE
vOneFS nodes can be created with different amounts of CPU cores

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,9 @@ services:
       - /mnt/raid/images/onefs:/images:ro
       - /mnt/tmp:/home
     environment:
-      - INF_VCENTER_SERVER=changeMe
-      - INF_VCENTER_USER=changeMe
-      - INF_VCENTER_PASSWORD=changeMe
+      - INF_VCENTER_SERVER=vlab-vcenter.emc.com
+      - INF_VCENTER_USER=willhn@vlab.local
+      - INF_VCENTER_PASSWORD=li84fe25
       - INF_VCENTER_DATASTORE=generalStorage,generalStorage2,generalStorage3
       - INF_VCENTER_TOP_LVL_DIR=/vlab/users
       - INF_VCENTER_RESORUCE_POOL=generalCompute

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -41,6 +41,7 @@ class TestTasks(unittest.TestCase):
                               front_end='externalNetwork',
                               back_end='internalNetwork',
                               ram=4,
+                              cpu_count=2,
                               txn_id='myId')
         expected = {'content' : {'worked': True}, 'error': None, 'params': {}}
 
@@ -57,6 +58,7 @@ class TestTasks(unittest.TestCase):
                               front_end='externalNetwork',
                               back_end='internalNetwork',
                               ram=4,
+                              cpu_count=2,
                               txn_id='myId')
         expected = {'content' : {}, 'error': 'testing', 'params': {}}
 

--- a/tests/test_vmware.py
+++ b/tests/test_vmware.py
@@ -58,6 +58,7 @@ class TestVMware(unittest.TestCase):
 
         self.assertEqual(output, expected)
 
+    @patch.object(vmware.virtual_machine, 'adjust_cpu')
     @patch.object(vmware.virtual_machine, 'adjust_ram')
     @patch.object(vmware.virtual_machine, 'set_meta')
     @patch.object(vmware, 'consume_task')
@@ -66,7 +67,9 @@ class TestVMware(unittest.TestCase):
     @patch.object(vmware.virtual_machine, 'get_info')
     @patch.object(vmware.virtual_machine, 'deploy_from_ova')
     @patch.object(vmware, 'vCenter')
-    def test_create_onefs(self, fake_vCenter, fake_deploy_from_ova, fake_get_info, fake_Ova, make_network_map, fake_consume_task, fake_set_meta, fake_adjust_ram):
+    def test_create_onefs(self, fake_vCenter, fake_deploy_from_ova, fake_get_info,
+                          fake_Ova, make_network_map, fake_consume_task, fake_set_meta,
+                          fake_adjust_ram, fake_adjust_cpu):
         """``create_onefs`` returns the new onefs's info when everything works"""
         fake_logger = MagicMock()
         fake_Ova.return_value.networks = ['vLabNetwork']
@@ -79,17 +82,21 @@ class TestVMware(unittest.TestCase):
                                      front_end='externalNetwork',
                                      back_end='internalNetwork',
                                      ram=4,
+                                     cpu_count=2,
                                      logger=fake_logger)
         expected = {'isi01': {'worked': True}}
 
         self.assertEqual(output, expected)
 
+    @patch.object(vmware.virtual_machine, 'adjust_cpu')
     @patch.object(vmware, 'consume_task')
     @patch.object(vmware, 'Ova')
     @patch.object(vmware.virtual_machine, 'get_info')
     @patch.object(vmware.virtual_machine, 'deploy_from_ova')
     @patch.object(vmware, 'vCenter')
-    def test_create_onefs_value_error(self, fake_vCenter, fake_deploy_from_ova, fake_get_info, fake_Ova, fake_consume_task):
+    def test_create_onefs_value_error(self, fake_vCenter, fake_deploy_from_ova,
+                                      fake_get_info, fake_Ova, fake_consume_task,
+                                      fake_adjust_cpu):
         """``create_onefs`` raises ValueError if supplied with a non-existing front_end network"""
         fake_logger = MagicMock()
         fake_Ova.return_value.networks = ['vLabNetwork']
@@ -103,6 +110,7 @@ class TestVMware(unittest.TestCase):
                                     front_end='not a thing',
                                     back_end='internalNetwork',
                                     ram=4,
+                                    cpu_count=2,
                                     logger=fake_logger)
 
     @patch.object(vmware, 'consume_task')
@@ -124,6 +132,7 @@ class TestVMware(unittest.TestCase):
                                     front_end='externallNetwork',
                                     back_end='not a thing',
                                     ram=4,
+                                    cpu_count=2,
                                     logger=fake_logger)
 
     @patch.object(vmware, 'consume_task')
@@ -145,6 +154,7 @@ class TestVMware(unittest.TestCase):
                                 front_end='externallNetwork',
                                 back_end='internalNetwork',
                                 ram=4,
+                                cpu_count=2,
                                 logger=fake_logger)
 
     @patch.object(vmware.virtual_machine, 'get_info')
@@ -186,6 +196,7 @@ class TestVMware(unittest.TestCase):
         with self.assertRaises(ValueError):
             vmware.delete_onefs(username='alice', machine_name='not a thing', logger=fake_logger)
 
+    @patch.object(vmware.virtual_machine, 'adjust_cpu')
     @patch.object(vmware.virtual_machine, 'adjust_ram')
     @patch.object(vmware.virtual_machine, 'set_meta')
     @patch.object(vmware, 'consume_task')
@@ -194,7 +205,9 @@ class TestVMware(unittest.TestCase):
     @patch.object(vmware.virtual_machine, 'get_info')
     @patch.object(vmware.virtual_machine, 'deploy_from_ova')
     @patch.object(vmware, 'vCenter')
-    def test_create_onefs_power(self, fake_vCenter, fake_deploy_from_ova, fake_get_info, fake_Ova, make_network_map, fake_consume_task, fake_set_meta, fake_adjust_ram):
+    def test_create_onefs_power(self, fake_vCenter, fake_deploy_from_ova, fake_get_info,
+                                fake_Ova, make_network_map, fake_consume_task,
+                                fake_set_meta, fake_adjust_ram, fake_adjust_cpu):
         """``create_onefs`` opts out of the deploy lib powering on the new VM"""
         fake_logger = MagicMock()
         fake_Ova.return_value.networks = ['vLabNetwork']
@@ -207,6 +220,7 @@ class TestVMware(unittest.TestCase):
                             front_end='externalNetwork',
                             back_end='internalNetwork',
                             ram=4,
+                            cpu_count=2,
                             logger=fake_logger)
         _, call_kwargs = fake_deploy_from_ova.call_args
         called_power = call_kwargs['power_on']
@@ -214,6 +228,7 @@ class TestVMware(unittest.TestCase):
 
         self.assertEqual(called_power, expected_power)
 
+    @patch.object(vmware.virtual_machine, 'adjust_cpu')
     @patch.object(vmware.virtual_machine, 'adjust_ram')
     @patch.object(vmware.virtual_machine, 'power')
     @patch.object(vmware.virtual_machine, 'set_meta')
@@ -223,7 +238,10 @@ class TestVMware(unittest.TestCase):
     @patch.object(vmware.virtual_machine, 'get_info')
     @patch.object(vmware.virtual_machine, 'deploy_from_ova')
     @patch.object(vmware, 'vCenter')
-    def test_create_onefs_power_false(self, fake_vCenter, fake_deploy_from_ova, fake_get_info, fake_Ova, make_network_map, fake_consume_task, fake_set_meta, fake_power, fake_adjust_ram):
+    def test_create_onefs_power_false(self, fake_vCenter, fake_deploy_from_ova,
+                                      fake_get_info, fake_Ova, make_network_map,
+                                      fake_consume_task, fake_set_meta, fake_power,
+                                      fake_adjust_ram, fake_adjust_cpu):
         """``create_onefs`` manually powers on the VM"""
         fake_logger = MagicMock()
         fake_Ova.return_value.networks = ['vLabNetwork']
@@ -236,6 +254,7 @@ class TestVMware(unittest.TestCase):
                             front_end='externalNetwork',
                             back_end='internalNetwork',
                             ram=4,
+                            cpu_count=2,
                             logger=fake_logger)
         _, call_kwargs = fake_power.call_args
         called_power = call_kwargs['state']
@@ -243,6 +262,7 @@ class TestVMware(unittest.TestCase):
 
         self.assertEqual(called_power, expected_power)
 
+    @patch.object(vmware.virtual_machine, 'adjust_cpu')
     @patch.object(vmware.virtual_machine, 'adjust_ram')
     @patch.object(vmware.virtual_machine, 'set_meta')
     @patch.object(vmware, 'consume_task')
@@ -251,7 +271,9 @@ class TestVMware(unittest.TestCase):
     @patch.object(vmware.virtual_machine, 'get_info')
     @patch.object(vmware.virtual_machine, 'deploy_from_ova')
     @patch.object(vmware, 'vCenter')
-    def test_create_onefs_ram(self, fake_vCenter, fake_deploy_from_ova, fake_get_info, fake_Ova, make_network_map, fake_consume_task, fake_set_meta, fake_adjust_ram):
+    def test_create_onefs_ram(self, fake_vCenter, fake_deploy_from_ova, fake_get_info,
+                              fake_Ova, make_network_map, fake_consume_task,
+                              fake_set_meta, fake_adjust_ram, fake_adjust_cpu):
         """``create_onefs`` sets the amount of RAM the VM has"""
         fake_logger = MagicMock()
         fake_Ova.return_value.networks = ['vLabNetwork']
@@ -264,10 +286,43 @@ class TestVMware(unittest.TestCase):
                             front_end='externalNetwork',
                             back_end='internalNetwork',
                             ram=4,
+                            cpu_count=2,
                             logger=fake_logger)
         _, call_kwargs = fake_adjust_ram.call_args
         defined_ram = call_kwargs['mb_of_ram']
         expected_ram = 4096
+
+        self.assertEqual(defined_ram, expected_ram)
+
+    @patch.object(vmware.virtual_machine, 'adjust_cpu')
+    @patch.object(vmware.virtual_machine, 'adjust_ram')
+    @patch.object(vmware.virtual_machine, 'set_meta')
+    @patch.object(vmware, 'consume_task')
+    @patch.object(vmware, 'make_network_map')
+    @patch.object(vmware, 'Ova')
+    @patch.object(vmware.virtual_machine, 'get_info')
+    @patch.object(vmware.virtual_machine, 'deploy_from_ova')
+    @patch.object(vmware, 'vCenter')
+    def test_create_onefs_cpu(self, fake_vCenter, fake_deploy_from_ova, fake_get_info,
+                              fake_Ova, make_network_map, fake_consume_task,
+                              fake_set_meta, fake_adjust_ram, fake_adjust_cpu):
+        """``create_onefs`` sets the amount of CPU cores the VM has"""
+        fake_logger = MagicMock()
+        fake_Ova.return_value.networks = ['vLabNetwork']
+        fake_get_info.return_value = {'worked' : True}
+        fake_deploy_from_ova.return_value.name = 'isi01'
+
+        vmware.create_onefs(username='alice',
+                            machine_name='isi01',
+                            image='8.0.0.4',
+                            front_end='externalNetwork',
+                            back_end='internalNetwork',
+                            ram=4,
+                            cpu_count=2,
+                            logger=fake_logger)
+        all_args, _ = fake_adjust_cpu.call_args
+        defined_ram = all_args[1]
+        expected_ram = 2
 
         self.assertEqual(defined_ram, expected_ram)
 

--- a/vlab_onefs_api/lib/views/onefs.py
+++ b/vlab_onefs_api/lib/views/onefs.py
@@ -50,6 +50,12 @@ class OneFSView(MachineView):
                             "type": "integer",
                             "default": 4,
                             "enum": [4, 6, 8, 10, 12]
+                        },
+                        "cpu-count": {
+                            "description": "The number of CPU cores to allocate to the VM",
+                            "type": "integer",
+                            "default": 2,
+                            "enum": [2, 4, 6, 8]
                         }
                     },
                     "required": ["name", 'image', 'frontend', 'backend']
@@ -201,7 +207,8 @@ class OneFSView(MachineView):
         front_end = '{}_{}'.format(username, body['frontend'])
         back_end = '{}_{}'.format(username, body['backend'])
         ram = body.get('ram', 4)
-        task = current_app.celery_app.send_task('onefs.create', [username, machine_name, image, front_end, back_end, ram, txn_id])
+        cpu_count = body.get('cpu-count', 2)
+        task = current_app.celery_app.send_task('onefs.create', [username, machine_name, image, front_end, back_end, ram, cpu_count, txn_id])
         resp_data['content'] = {'task-id': task.id}
         resp = Response(ujson.dumps(resp_data))
         resp.status_code = 202

--- a/vlab_onefs_api/lib/worker/tasks.py
+++ b/vlab_onefs_api/lib/worker/tasks.py
@@ -38,7 +38,7 @@ def show(self, username, txn_id):
 
 
 @app.task(name='onefs.create', bind=True)
-def create(self, username, machine_name, image, front_end, back_end, ram, txn_id):
+def create(self, username, machine_name, image, front_end, back_end, ram, cpu_count, txn_id):
     """Deploy a new OneFS node
 
     :Returns: Dictionary
@@ -61,6 +61,9 @@ def create(self, username, machine_name, image, front_end, back_end, ram, txn_id
     :param ram: The number of GB of memory to provision the node with
     :type ram: Integer
 
+    :param cpu_count: The number of CPU cores to allocate to the vOneFS node
+    :type cpu_count: Integer
+
     :param txn_id: A unique string supplied by the client to track the call through logs
     :type txn_id: String
     """
@@ -68,7 +71,7 @@ def create(self, username, machine_name, image, front_end, back_end, ram, txn_id
     resp = {'content' : {}, 'error': None, 'params': {}}
     logger.info('Task starting')
     try:
-        resp['content'] = vmware.create_onefs(username, machine_name, image, front_end, back_end, ram, logger)
+        resp['content'] = vmware.create_onefs(username, machine_name, image, front_end, back_end, ram, cpu_count, logger)
     except ValueError as doh:
         logger.error('Task failed: {}'.format(doh))
         resp['error'] = '{}'.format(doh)

--- a/vlab_onefs_api/lib/worker/vmware.py
+++ b/vlab_onefs_api/lib/worker/vmware.py
@@ -60,7 +60,7 @@ def delete_onefs(username, machine_name, logger):
             raise ValueError('No OneFS node named {} found'.format(machine_name))
 
 
-def create_onefs(username, machine_name, image, front_end, back_end, ram, logger):
+def create_onefs(username, machine_name, image, front_end, back_end, ram, cpu_count, logger):
     """Deploy a OneFS node
 
     :Returns: Dictionary
@@ -82,6 +82,9 @@ def create_onefs(username, machine_name, image, front_end, back_end, ram, logger
 
     :param ram: The number of GB of memory to provision the node with
     :type ram: Integer
+
+    :param cpu_count: The number of CPU cores to allocate to the vOneFS node
+    :type cpu_count: Integer
 
     :param logger: An object for logging messages
     :type logger: logging.LoggerAdapter
@@ -108,6 +111,7 @@ def create_onefs(username, machine_name, image, front_end, back_end, ram, logger
         # ram is supplied in GB
         mb_of_ram = ram * 1024
         virtual_machine.adjust_ram(the_vm, mb_of_ram=mb_of_ram)
+        virtual_machine.adjust_cpu(the_vm, cpu_count)
         virtual_machine.power(the_vm, state='on')
         meta_data = {'component': 'OneFS',
                      'created': time.time(),


### PR DESCRIPTION
Adding this feature is pretty trivial, and (of those that voted) people think it would be handy:

![image](https://user-images.githubusercontent.com/12264343/78378983-92f7c400-7586-11ea-95ec-f7a025254b28.png)
